### PR TITLE
Add diff subcommand for comparing labeled database snapshots

### DIFF
--- a/.changes/unreleased/Added-20260627-005611.yaml
+++ b/.changes/unreleased/Added-20260627-005611.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Diff function, as a user you can now pass in a database with labels and get a table prin out of what is new, updated, or removed between the labels.
+time: 2026-06-27T00:56:11.543677382+01:00

--- a/.changes/unreleased/Added-20260627-011730.yaml
+++ b/.changes/unreleased/Added-20260627-011730.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: diff command json output. Now calling the diff function with `--output=json` will send the differences between labels to standard out in a json blob.
+time: 2026-06-27T01:17:30.504501393+01:00

--- a/.changes/unreleased/Added-20260627-015822.yaml
+++ b/.changes/unreleased/Added-20260627-015822.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Exclude filtering for diff command. The diff command can now filter out resources when using -e/--exclude flag.
+time: 2026-06-27T01:58:22.794003891+01:00

--- a/.changes/unreleased/Changed-20260627-020039.yaml
+++ b/.changes/unreleased/Changed-20260627-020039.yaml
@@ -1,3 +1,3 @@
 kind: Changed
-body: The `get` command has had a change in how the exclude flag works. It will now match parical kinds. For example using `--exclude events` will exclude V1.Events and events.k8s.io/v1.Events.
+body: The `get` command exclude flag now uses case-insensitive full-string matching against both the CRD resource name and the resolved Kind name. For example `--exclude events` matches the CRD name `events`, and `--exclude event` matches the Kind `Event`.
 time: 2026-06-27T02:00:39.769881601+01:00

--- a/.changes/unreleased/Changed-20260627-020039.yaml
+++ b/.changes/unreleased/Changed-20260627-020039.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: The `get` command has had a change in how the exclude flag works. It will now match parical kinds. For example using `--exclude events` will exclude V1.Events and events.k8s.io/v1.Events.
+time: 2026-06-27T02:00:39.769881601+01:00

--- a/src/args.zig
+++ b/src/args.zig
@@ -1,0 +1,22 @@
+const clap = @import("clap");
+const types = @import("types.zig");
+
+const SubCommands = enum {
+    get,
+    diff,
+};
+
+pub const main_parsers = .{
+    .command = clap.parsers.enumeration(SubCommands),
+    .LEVEL = clap.parsers.enumeration(types.Level),
+};
+
+pub const main_params = clap.parseParamsComptime(
+    \\-h, --help Display tihs help and exit.
+    \\--version Display version, and exit.
+    \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Defualt level is warn.
+    \\<command>
+    \\
+);
+
+pub const MainArgs = clap.ResultEx(clap.Help, &main_params, main_parsers);

--- a/src/args.zig
+++ b/src/args.zig
@@ -1,5 +1,5 @@
 const clap = @import("clap");
-const types = @import("types.zig");
+const logging = @import("log.zig");
 
 const SubCommands = enum {
     get,
@@ -8,7 +8,7 @@ const SubCommands = enum {
 
 pub const main_parsers = .{
     .command = clap.parsers.enumeration(SubCommands),
-    .LEVEL = clap.parsers.enumeration(types.Level),
+    .LEVEL = clap.parsers.enumeration(logging.Level),
 };
 
 pub const main_params = clap.parseParamsComptime(

--- a/src/args.zig
+++ b/src/args.zig
@@ -12,11 +12,9 @@ pub const main_parsers = .{
 };
 
 pub const main_params = clap.parseParamsComptime(
-    \\-h, --help Display tihs help and exit.
+    \\-h, --help Display this help and exit.
     \\--version Display version, and exit.
-    \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Defualt level is warn.
+    \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Default level is warn.
     \\<command>
     \\
 );
-
-pub const MainArgs = clap.ResultEx(clap.Help, &main_params, main_parsers);

--- a/src/database.zig
+++ b/src/database.zig
@@ -14,6 +14,18 @@ pub fn init(database: []const u8) !void {
     try db.exec("CREATE TABLE IF NOT EXISTS results(id INTEGER PRIMARY KEY AUTOINCREMENT, apiVersion, kind, name, namespace, creationTimestamp, resourceVersion, generation, resultTimestamp, resultLabel)", .{});
 }
 
+pub fn added(label_a: []const u8, label_b: []const u8) void {
+    std.log.debug("getting newer resource under label: {s}, compared to label: {s}", .{ label_a, label_b });
+}
+
+pub fn updated(label_a: []const u8, label_b: []const u8) void {
+    std.log.debug("getting updated resource under label: {s}, compared to label: {s}", .{ label_a, label_b });
+}
+
+pub fn deleted(label_a: []const u8, label_b: []const u8) void {
+    std.log.debug("getting deleted resource under label: {s}, compared to label: {s}", .{ label_a, label_b });
+}
+
 pub fn add(enties: types.ResourceList, label: ?[]const u8, timestamp: i64) !void {
     var _label: ?sqlite.Text = null;
     if (label) |l| _label = sqlite.text(l);

--- a/src/database.zig
+++ b/src/database.zig
@@ -14,28 +14,28 @@ pub fn init(database: []const u8) !void {
     try db.exec("CREATE TABLE IF NOT EXISTS results(id INTEGER PRIMARY KEY AUTOINCREMENT, apiVersion, kind, name, namespace, creationTimestamp, resourceVersion, generation, resultTimestamp, resultLabel)", .{});
 }
 
-pub fn added(allocator: std.mem.Allocator, label_a: []const u8, label_b: []const u8) !types.ResourceList {
-    std.log.debug("getting newer resource under label: {s}, compared to label: {s}", .{ label_b, label_a });
+pub fn added(allocator: std.mem.Allocator, config: types.DiffConfig) !types.ResourceList {
+    std.log.debug("getting newer resource under label: {s}, compared to label: {s}", .{ config.label_b, config.label_a });
     return queryResources(allocator, added_sql, .{
-        .label_a = sqlite.text(label_a),
-        .label_b = sqlite.text(label_b),
-    });
+        .label_a = sqlite.text(config.label_a),
+        .label_b = sqlite.text(config.label_b),
+    }, config.exclude);
 }
 
-pub fn updated(allocator: std.mem.Allocator, label_a: []const u8, label_b: []const u8) !types.ResourceList {
-    std.log.debug("getting updated resource under label: {s}, compared to label: {s}", .{ label_b, label_a });
+pub fn updated(allocator: std.mem.Allocator, config: types.DiffConfig) !types.ResourceList {
+    std.log.debug("getting updated resource under label: {s}, compared to label: {s}", .{ config.label_b, config.label_a });
     return queryResources(allocator, updated_sql, .{
-        .label_a = sqlite.text(label_a),
-        .label_b = sqlite.text(label_b),
-    });
+        .label_a = sqlite.text(config.label_a),
+        .label_b = sqlite.text(config.label_b),
+    }, config.exclude);
 }
 
-pub fn deleted(allocator: std.mem.Allocator, label_a: []const u8, label_b: []const u8) !types.ResourceList {
-    std.log.debug("getting deleted resource under label: {s}, compared to label: {s}", .{ label_a, label_b });
+pub fn deleted(allocator: std.mem.Allocator, config: types.DiffConfig) !types.ResourceList {
+    std.log.debug("getting deleted resource under label: {s}, compared to label: {s}", .{ config.label_a, config.label_b });
     return queryResources(allocator, deleted_sql, .{
-        .label_a = sqlite.text(label_a),
-        .label_b = sqlite.text(label_b),
-    });
+        .label_a = sqlite.text(config.label_a),
+        .label_b = sqlite.text(config.label_b),
+    }, config.exclude);
 }
 
 pub fn add(enties: types.ResourceList, label: ?[]const u8, timestamp: i64) !void {
@@ -118,7 +118,16 @@ const DiffRow = struct {
     generation: ?i64,
 };
 
-fn queryResources(allocator: std.mem.Allocator, comptime sql: []const u8, params: DiffParams) !types.ResourceList {
+fn matchedExclude(haystack: ?[]const []const u8, needle: []const u8) ?[]const u8 {
+    if (haystack) |stack| {
+        for (stack) |s| {
+            if (std.ascii.eqlIgnoreCase(s, needle)) return s;
+        }
+    }
+    return null;
+}
+
+fn queryResources(allocator: std.mem.Allocator, comptime sql: []const u8, params: DiffParams, exclude: ?[]const []const u8) !types.ResourceList {
     const stmt = try db.prepare(DiffParams, DiffRow, sql);
     defer stmt.finalize();
 
@@ -131,6 +140,10 @@ fn queryResources(allocator: std.mem.Allocator, comptime sql: []const u8, params
     }
 
     while (try stmt.step()) |row| {
+        if (matchedExclude(exclude, row.kind.data)) |matched| {
+            std.log.debug("excluding {s}/{s} matched by -e {s}", .{ row.apiVersion.data, row.kind.data, matched });
+            continue;
+        }
         const resource = types.Resource{
             .kind = try allocator.dupe(u8, row.kind.data),
             .apiVersion = try allocator.dupe(u8, row.apiVersion.data),

--- a/src/database.zig
+++ b/src/database.zig
@@ -33,7 +33,7 @@ pub fn add(enties: types.ResourceList, label: ?[]const u8, timestamp: i64) !void
             .name = sqlite.text(entry.metadata.name),
             .namespace = sqlite.text(entry.metadata.namespace),
             .creationTimestamp = sqlite.text(entry.metadata.creationTimestamp),
-            .resourceVersion = sqlite.text(entry.metadata.resourceVersion.?),
+            .resourceVersion = if (entry.metadata.resourceVersion) |rv| sqlite.text(rv) else sqlite.text(""),
             .generation = entry.metadata.generation,
             .resultTimestamp = timestamp,
             .resultLabel = _label,

--- a/src/database.zig
+++ b/src/database.zig
@@ -14,16 +14,28 @@ pub fn init(database: []const u8) !void {
     try db.exec("CREATE TABLE IF NOT EXISTS results(id INTEGER PRIMARY KEY AUTOINCREMENT, apiVersion, kind, name, namespace, creationTimestamp, resourceVersion, generation, resultTimestamp, resultLabel)", .{});
 }
 
-pub fn added(label_a: []const u8, label_b: []const u8) void {
-    std.log.debug("getting newer resource under label: {s}, compared to label: {s}", .{ label_a, label_b });
+pub fn added(allocator: std.mem.Allocator, label_a: []const u8, label_b: []const u8) !types.ResourceList {
+    std.log.debug("getting newer resource under label: {s}, compared to label: {s}", .{ label_b, label_a });
+    return queryResources(allocator, added_sql, .{
+        .label_a = sqlite.text(label_a),
+        .label_b = sqlite.text(label_b),
+    });
 }
 
-pub fn updated(label_a: []const u8, label_b: []const u8) void {
-    std.log.debug("getting updated resource under label: {s}, compared to label: {s}", .{ label_a, label_b });
+pub fn updated(allocator: std.mem.Allocator, label_a: []const u8, label_b: []const u8) !types.ResourceList {
+    std.log.debug("getting updated resource under label: {s}, compared to label: {s}", .{ label_b, label_a });
+    return queryResources(allocator, updated_sql, .{
+        .label_a = sqlite.text(label_a),
+        .label_b = sqlite.text(label_b),
+    });
 }
 
-pub fn deleted(label_a: []const u8, label_b: []const u8) void {
+pub fn deleted(allocator: std.mem.Allocator, label_a: []const u8, label_b: []const u8) !types.ResourceList {
     std.log.debug("getting deleted resource under label: {s}, compared to label: {s}", .{ label_a, label_b });
+    return queryResources(allocator, deleted_sql, .{
+        .label_a = sqlite.text(label_a),
+        .label_b = sqlite.text(label_b),
+    });
 }
 
 pub fn add(enties: types.ResourceList, label: ?[]const u8, timestamp: i64) !void {
@@ -51,6 +63,89 @@ pub fn add(enties: types.ResourceList, label: ?[]const u8, timestamp: i64) !void
             .resultLabel = _label,
         });
     }
+}
+
+const added_sql =
+    \\SELECT apiVersion, kind, name, namespace, creationTimestamp, resourceVersion, generation
+    \\FROM results r1
+    \\WHERE r1.resultLabel = :label_b
+    \\AND NOT EXISTS (
+    \\    SELECT 1 FROM results r2
+    \\    WHERE r2.resultLabel = :label_a
+    \\    AND r2.name = r1.name AND r2.namespace = r1.namespace
+    \\    AND r2.kind = r1.kind AND r2.apiVersion = r1.apiVersion
+    \\)
+    \\ORDER BY r1.kind, r1.name
+;
+
+const deleted_sql =
+    \\SELECT apiVersion, kind, name, namespace, creationTimestamp, resourceVersion, generation
+    \\FROM results r1
+    \\WHERE r1.resultLabel = :label_a
+    \\AND NOT EXISTS (
+    \\    SELECT 1 FROM results r2
+    \\    WHERE r2.resultLabel = :label_b
+    \\    AND r2.name = r1.name AND r2.namespace = r1.namespace
+    \\    AND r2.kind = r1.kind AND r2.apiVersion = r1.apiVersion
+    \\)
+    \\ORDER BY r1.kind, r1.name
+;
+
+const updated_sql =
+    \\SELECT r2.apiVersion, r2.kind, r2.name, r2.namespace, r2.creationTimestamp, r2.resourceVersion, r2.generation
+    \\FROM results r1
+    \\JOIN results r2
+    \\    ON r1.name = r2.name AND r1.namespace = r2.namespace
+    \\    AND r1.kind = r2.kind AND r1.apiVersion = r2.apiVersion
+    \\WHERE r1.resultLabel = :label_a AND r2.resultLabel = :label_b
+    \\AND (r1.resourceVersion != r2.resourceVersion
+    \\     OR (r1.resourceVersion = r2.resourceVersion AND r1.generation != r2.generation))
+    \\ORDER BY r2.kind, r2.name
+;
+
+const DiffParams = struct {
+    label_a: sqlite.Text,
+    label_b: sqlite.Text,
+};
+
+const DiffRow = struct {
+    apiVersion: sqlite.Text,
+    kind: sqlite.Text,
+    name: sqlite.Text,
+    namespace: sqlite.Text,
+    creationTimestamp: sqlite.Text,
+    resourceVersion: sqlite.Text,
+    generation: ?i64,
+};
+
+fn queryResources(allocator: std.mem.Allocator, comptime sql: []const u8, params: DiffParams) !types.ResourceList {
+    const stmt = try db.prepare(DiffParams, DiffRow, sql);
+    defer stmt.finalize();
+
+    try stmt.bind(params);
+
+    var items: std.ArrayList(types.Resource) = .empty;
+    errdefer {
+        for (items.items) |item| item.deinit(allocator);
+        items.deinit(allocator);
+    }
+
+    while (try stmt.step()) |row| {
+        const resource = types.Resource{
+            .kind = try allocator.dupe(u8, row.kind.data),
+            .apiVersion = try allocator.dupe(u8, row.apiVersion.data),
+            .metadata = .{
+                .name = try allocator.dupe(u8, row.name.data),
+                .namespace = try allocator.dupe(u8, row.namespace.data),
+                .creationTimestamp = try allocator.dupe(u8, row.creationTimestamp.data),
+                .resourceVersion = if (row.resourceVersion.data.len > 0) try allocator.dupe(u8, row.resourceVersion.data) else null,
+                .generation = if (row.generation) |g| @as(u64, @intCast(g)) else null,
+            },
+        };
+        try items.append(allocator, resource);
+    }
+
+    return types.ResourceList{ .items = try items.toOwnedSlice(allocator) };
 }
 
 const Entry = struct {

--- a/src/database.zig
+++ b/src/database.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const sqlite = @import("sqlite");
 const types = @import("types.zig");
+const utils = @import("utils.zig");
 
 var db: sqlite.Database = undefined;
 
@@ -118,15 +119,6 @@ const DiffRow = struct {
     generation: ?i64,
 };
 
-fn matchedExclude(haystack: ?[]const []const u8, needle: []const u8) ?[]const u8 {
-    if (haystack) |stack| {
-        for (stack) |s| {
-            if (std.ascii.eqlIgnoreCase(s, needle)) return s;
-        }
-    }
-    return null;
-}
-
 fn queryResources(allocator: std.mem.Allocator, comptime sql: []const u8, params: DiffParams, exclude: ?[]const []const u8) !types.ResourceList {
     const stmt = try db.prepare(DiffParams, DiffRow, sql);
     defer stmt.finalize();
@@ -140,7 +132,7 @@ fn queryResources(allocator: std.mem.Allocator, comptime sql: []const u8, params
     }
 
     while (try stmt.step()) |row| {
-        if (matchedExclude(exclude, row.kind.data)) |matched| {
+        if (utils.matchedExclude(exclude, row.kind.data)) |matched| {
             std.log.debug("excluding {s}/{s} matched by -e {s}", .{ row.apiVersion.data, row.kind.data, matched });
             continue;
         }

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -3,6 +3,7 @@ const args = @import("args.zig");
 const clap = @import("clap");
 const logging = @import("log.zig");
 const db = @import("database.zig");
+const table = @import("table.zig");
 const types = @import("types.zig");
 
 pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iterator, main_args: args.MainArgs) !void {
@@ -52,14 +53,37 @@ pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iter
     };
     std.log.debug("{f}", .{config});
 
-    std.debug.print("running diff\ndatabase: {s}\nlabel A: {s}\nlabel B: {s}\n", .{ database, label_a, label_b });
     try db.init(config.database);
+
     try section(io, "Added Resources");
-    db.added(config.label_a, config.label_b);
+    const added_resources = try db.added(gpa, config.label_a, config.label_b);
+    defer added_resources.deinit(gpa);
+    try printByKind(io, added_resources);
+
     try section(io, "Updated Resources");
-    db.updated(config.label_a, config.label_b);
+    const updated_resources = try db.updated(gpa, config.label_a, config.label_b);
+    defer updated_resources.deinit(gpa);
+    try printByKind(io, updated_resources);
+
     try section(io, "Removed Resources");
-    db.deleted(config.label_a, config.label_b);
+    const deleted_resources = try db.deleted(gpa, config.label_a, config.label_b);
+    defer deleted_resources.deinit(gpa);
+    try printByKind(io, deleted_resources);
+}
+
+fn printByKind(io: std.Io, resources: types.ResourceList) !void {
+    if (resources.items.len == 0) return;
+
+    var start: usize = 0;
+    while (start < resources.items.len) {
+        const kind = resources.items[start].kind;
+        var end = start + 1;
+        while (end < resources.items.len and std.mem.eql(u8, resources.items[end].kind, kind)) {
+            end += 1;
+        }
+        try table.print(io, .{ .items = resources.items[start..end] });
+        start = end;
+    }
 }
 
 fn section(io: std.Io, header: []const u8) !void {

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+const args = @import("args.zig");
+const clap = @import("clap");
+const types = @import("types.zig");
+
+pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iterator, main_args: args.MainArgs) !void {
+    _ = main_args;
+
+    const params = comptime clap.parseParamsComptime(
+        \\-h, --help Display this help and exit.
+        \\-d, --database <PATH> Path to SQLite database to load data from.
+        \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Defualt level is warn.
+        \\<LABEL> Older label used.
+        \\<LABEL> Newer label used.
+        \\
+    );
+
+    const parsers = comptime .{
+        .PATH = clap.parsers.string,
+        .LABEL = clap.parsers.string,
+        .LEVEL = clap.parsers.enumeration(types.Level),
+    };
+
+    var diag = clap.Diagnostic{};
+    var res = clap.parseEx(clap.Help, &params, parsers, iter, .{
+        .diagnostic = &diag,
+        .allocator = gpa,
+    }) catch |err| {
+        // Report useful error and exit.
+        try diag.reportToFile(io, .stderr(), err);
+        return err;
+    };
+    defer res.deinit();
+
+    var level = types.Level.warn;
+
+    if (res.args.help != 0)
+        return clap.helpToFile(io, .stdout(), clap.Help, &params, .{});
+
+    if (res.args.@"log-level") |l| {
+        level = l;
+    }
+
+    const database = res.args.database orelse return error.MissingDatabase;
+    const label_a = res.positionals[0] orelse return error.MissingArg1;
+    const label_b = res.positionals[1] orelse return error.MissingArg2;
+
+    std.debug.print("running diff\ndatabase: {s}\nlabel A: {s}\nlabel B: {s}\n", .{ database, label_a, label_b });
+}

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const args = @import("args.zig");
 const clap = @import("clap");
+const logging = @import("log.zig");
 const types = @import("types.zig");
 
 pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iterator, main_args: args.MainArgs) !void {
@@ -18,7 +19,7 @@ pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iter
     const parsers = comptime .{
         .PATH = clap.parsers.string,
         .LABEL = clap.parsers.string,
-        .LEVEL = clap.parsers.enumeration(types.Level),
+        .LEVEL = clap.parsers.enumeration(logging.Level),
     };
 
     var diag = clap.Diagnostic{};
@@ -32,13 +33,11 @@ pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iter
     };
     defer res.deinit();
 
-    var level = types.Level.warn;
-
     if (res.args.help != 0)
         return clap.helpToFile(io, .stdout(), clap.Help, &params, .{});
 
     if (res.args.@"log-level") |l| {
-        level = l;
+        logging.setLogLevel(l);
     }
 
     const database = res.args.database orelse return error.MissingDatabase;

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const args = @import("args.zig");
 const clap = @import("clap");
 const logging = @import("log.zig");
+const db = @import("database.zig");
 const types = @import("types.zig");
 
 pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iterator, main_args: args.MainArgs) !void {
@@ -44,5 +45,28 @@ pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iter
     const label_a = res.positionals[0] orelse return error.MissingArg1;
     const label_b = res.positionals[1] orelse return error.MissingArg2;
 
+    const config = types.DiffConfig{
+        .database = database,
+        .label_a = label_a,
+        .label_b = label_b,
+    };
+    std.log.debug("{f}", .{config});
+
     std.debug.print("running diff\ndatabase: {s}\nlabel A: {s}\nlabel B: {s}\n", .{ database, label_a, label_b });
+    try db.init(config.database);
+    try section(io, "Added Resources");
+    db.added(config.label_a, config.label_b);
+    try section(io, "Updated Resources");
+    db.updated(config.label_a, config.label_b);
+    try section(io, "Removed Resources");
+    db.deleted(config.label_a, config.label_b);
+}
+
+fn section(io: std.Io, header: []const u8) !void {
+    var buf: [4096]u8 = undefined;
+    var file_writer = std.Io.File.stdout().writer(io, &buf);
+    const stdout = &file_writer.interface;
+
+    try stdout.print("========== {s} ==========\n", .{header});
+    try stdout.flush();
 }

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -72,7 +72,10 @@ pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iter
 }
 
 fn printByKind(io: std.Io, resources: types.ResourceList) !void {
-    if (resources.items.len == 0) return;
+    if (resources.items.len == 0) {
+        std.log.debug("Resource list is emtpy, early exit.", .{});
+        return;
+    }
 
     var start: usize = 0;
     while (start < resources.items.len) {
@@ -91,6 +94,16 @@ fn section(io: std.Io, header: []const u8) !void {
     var file_writer = std.Io.File.stdout().writer(io, &buf);
     const stdout = &file_writer.interface;
 
-    try stdout.print("========== {s} ==========\n", .{header});
+    const width = 40;
+    const color_start = "\x1b[1;31m";
+    const reset = "\x1b[0m";
+    const separator = "=" ** width;
+    const padding = (width - header.len) / 2;
+
+    try stdout.print("\n{s}{s}\n", .{ color_start, separator });
+    for (0..padding) |_| {
+        try stdout.print(" ", .{});
+    }
+    try stdout.print("{s}\n{s}{s}\n\n", .{ header, separator, reset });
     try stdout.flush();
 }

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -1,20 +1,18 @@
 const std = @import("std");
-const args = @import("args.zig");
 const clap = @import("clap");
 const logging = @import("log.zig");
 const db = @import("database.zig");
 const table = @import("table.zig");
 const types = @import("types.zig");
 
-pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iterator, main_args: args.MainArgs) !void {
-    _ = main_args;
+pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
 
     const params = comptime clap.parseParamsComptime(
         \\-h, --help Display this help and exit.
         \\-d, --database <PATH> Path to SQLite database to load data from.
         \\-e, --exclude <STR>... Exclude resource types. Multiple can be excluded eg: "-e <KIND> -e <KIND>"
         \\-o, --output <OUTPUT> Changes the output format of the results. [default: tty, tty|json]
-        \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Defualt level is warn.
+        \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Default level is warn.
         \\<LABEL> Older label used.
         \\<LABEL> Newer label used.
         \\
@@ -132,7 +130,7 @@ fn printSection(io: std.Io, header: []const u8, resources: types.ResourceList, w
 
 fn printByKind(io: std.Io, resources: types.ResourceList) !void {
     if (resources.items.len == 0) {
-        std.log.debug("Resource list is emtpy, early exit.", .{});
+        std.log.debug("Resource list is empty, early exit.", .{});
         return;
     }
 

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -12,6 +12,7 @@ pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iter
     const params = comptime clap.parseParamsComptime(
         \\-h, --help Display this help and exit.
         \\-d, --database <PATH> Path to SQLite database to load data from.
+        \\-o, --output <OUTPUT> Changes the output format of the results. [default: tty, tty|json]
         \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Defualt level is warn.
         \\<LABEL> Older label used.
         \\<LABEL> Newer label used.
@@ -22,6 +23,7 @@ pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iter
         .PATH = clap.parsers.string,
         .LABEL = clap.parsers.string,
         .LEVEL = clap.parsers.enumeration(logging.Level),
+        .OUTPUT = clap.parsers.enumeration(types.Output),
     };
 
     var diag = clap.Diagnostic{};
@@ -50,6 +52,7 @@ pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iter
         .database = database,
         .label_a = label_a,
         .label_b = label_b,
+        .output = res.args.output orelse .tty,
     };
     std.log.debug("{f}", .{config});
 
@@ -62,11 +65,53 @@ pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iter
     const deleted_resources = try db.deleted(gpa, config.label_a, config.label_b);
     defer deleted_resources.deinit(gpa);
 
-    const max_width = maxTableWidth(added_resources, updated_resources, deleted_resources);
+    switch (config.output) {
+        .tty => {
+            const max_width = maxTableWidth(added_resources, updated_resources, deleted_resources);
+            try printSection(io, "Added Resources", added_resources, max_width);
+            try printSection(io, "Updated Resources", updated_resources, max_width);
+            try printSection(io, "Removed Resources", deleted_resources, max_width);
+        },
+        .json => {
+            try printJson(io, gpa, added_resources, updated_resources, deleted_resources);
+        },
+        .sqlite => {
+            std.log.err("sqlite output is not supported for diff", .{});
+            std.process.exit(1);
+        },
+    }
+}
 
-    try printSection(io, "Added Resources", added_resources, max_width);
-    try printSection(io, "Updated Resources", updated_resources, max_width);
-    try printSection(io, "Removed Resources", deleted_resources, max_width);
+fn printJson(io: std.Io, gpa: std.mem.Allocator, added: types.ResourceList, updated: types.ResourceList, deleted: types.ResourceList) !void {
+    var buf: [4096]u8 = undefined;
+    var file_writer = std.Io.File.stdout().writer(io, &buf);
+    const stdout = &file_writer.interface;
+
+    try stdout.print("{{\"added\": ", .{});
+    try printResourceListJson(stdout, gpa, added);
+    try stdout.print(", \"updated\": ", .{});
+    try printResourceListJson(stdout, gpa, updated);
+    try stdout.print(", \"deleted\": ", .{});
+    try printResourceListJson(stdout, gpa, deleted);
+    try stdout.print("}}\n", .{});
+    try stdout.flush();
+}
+
+fn printResourceListJson(stdout: *std.Io.Writer, gpa: std.mem.Allocator, resources: types.ResourceList) !void {
+    if (resources.items.len == 0) {
+        try stdout.print("[]", .{});
+        return;
+    }
+    try stdout.print("[", .{});
+    for (resources.items, 0..) |item, i| {
+        const text = try item.toJson(gpa);
+        defer gpa.free(text);
+        try stdout.print("{s}", .{text});
+        if (i < resources.items.len - 1) {
+            try stdout.print(",", .{});
+        }
+    }
+    try stdout.print("]", .{});
 }
 
 fn maxTableWidth(added: types.ResourceList, updated: types.ResourceList, deleted: types.ResourceList) usize {

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -12,6 +12,7 @@ pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iter
     const params = comptime clap.parseParamsComptime(
         \\-h, --help Display this help and exit.
         \\-d, --database <PATH> Path to SQLite database to load data from.
+        \\-e, --exclude <STR>... Exclude resource types. Multiple can be excluded eg: "-e <KIND> -e <KIND>"
         \\-o, --output <OUTPUT> Changes the output format of the results. [default: tty, tty|json]
         \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Defualt level is warn.
         \\<LABEL> Older label used.
@@ -21,6 +22,7 @@ pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iter
 
     const parsers = comptime .{
         .PATH = clap.parsers.string,
+        .STR = clap.parsers.string,
         .LABEL = clap.parsers.string,
         .LEVEL = clap.parsers.enumeration(logging.Level),
         .OUTPUT = clap.parsers.enumeration(types.Output),
@@ -44,25 +46,22 @@ pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iter
         logging.setLogLevel(l);
     }
 
-    const database = res.args.database orelse return error.MissingDatabase;
-    const label_a = res.positionals[0] orelse return error.MissingArg1;
-    const label_b = res.positionals[1] orelse return error.MissingArg2;
-
     const config = types.DiffConfig{
-        .database = database,
-        .label_a = label_a,
-        .label_b = label_b,
+        .database = res.args.database orelse return error.MissingDatabase,
+        .label_a = res.positionals[0] orelse return error.MissingArg1,
+        .label_b = res.positionals[1] orelse return error.MissingArg2,
         .output = res.args.output orelse .tty,
+        .exclude = if (res.args.exclude.len > 0) res.args.exclude else null,
     };
     std.log.debug("{f}", .{config});
 
     try db.init(config.database);
 
-    const added_resources = try db.added(gpa, config.label_a, config.label_b);
+    const added_resources = try db.added(gpa, config);
     defer added_resources.deinit(gpa);
-    const updated_resources = try db.updated(gpa, config.label_a, config.label_b);
+    const updated_resources = try db.updated(gpa, config);
     defer updated_resources.deinit(gpa);
-    const deleted_resources = try db.deleted(gpa, config.label_a, config.label_b);
+    const deleted_resources = try db.deleted(gpa, config);
     defer deleted_resources.deinit(gpa);
 
     switch (config.output) {

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -55,20 +55,35 @@ pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iter
 
     try db.init(config.database);
 
-    try section(io, "Added Resources");
     const added_resources = try db.added(gpa, config.label_a, config.label_b);
     defer added_resources.deinit(gpa);
-    try printByKind(io, added_resources);
-
-    try section(io, "Updated Resources");
     const updated_resources = try db.updated(gpa, config.label_a, config.label_b);
     defer updated_resources.deinit(gpa);
-    try printByKind(io, updated_resources);
-
-    try section(io, "Removed Resources");
     const deleted_resources = try db.deleted(gpa, config.label_a, config.label_b);
     defer deleted_resources.deinit(gpa);
-    try printByKind(io, deleted_resources);
+
+    const max_width = maxTableWidth(added_resources, updated_resources, deleted_resources);
+
+    try printSection(io, "Added Resources", added_resources, max_width);
+    try printSection(io, "Updated Resources", updated_resources, max_width);
+    try printSection(io, "Removed Resources", deleted_resources, max_width);
+}
+
+fn maxTableWidth(added: types.ResourceList, updated: types.ResourceList, deleted: types.ResourceList) usize {
+    var max: usize = 40;
+    if (added.items.len > 0) max = @max(max, table.calcWidth(added));
+    if (updated.items.len > 0) max = @max(max, table.calcWidth(updated));
+    if (deleted.items.len > 0) max = @max(max, table.calcWidth(deleted));
+    return max;
+}
+
+fn printSection(io: std.Io, header: []const u8, resources: types.ResourceList, width: usize) !void {
+    if (resources.items.len == 0) {
+        std.log.debug("{s}: no resources found, skipping.", .{header});
+        return;
+    }
+    try section(io, header, width);
+    try printByKind(io, resources);
 }
 
 fn printByKind(io: std.Io, resources: types.ResourceList) !void {
@@ -89,21 +104,21 @@ fn printByKind(io: std.Io, resources: types.ResourceList) !void {
     }
 }
 
-fn section(io: std.Io, header: []const u8) !void {
+fn section(io: std.Io, header: []const u8, width: usize) !void {
     var buf: [4096]u8 = undefined;
     var file_writer = std.Io.File.stdout().writer(io, &buf);
     const stdout = &file_writer.interface;
 
-    const width = 40;
-    const color_start = "\x1b[1;31m";
+    const color_start = "\x1b[1;33m";
     const reset = "\x1b[0m";
-    const separator = "=" ** width;
     const padding = (width - header.len) / 2;
 
-    try stdout.print("\n{s}{s}\n", .{ color_start, separator });
-    for (0..padding) |_| {
-        try stdout.print(" ", .{});
-    }
-    try stdout.print("{s}\n{s}{s}\n\n", .{ header, separator, reset });
+    try stdout.print("\n{s}", .{color_start});
+    for (0..width) |_| try stdout.print("=", .{});
+    try stdout.print("\n", .{});
+    for (0..padding) |_| try stdout.print(" ", .{});
+    try stdout.print("{s}\n", .{header});
+    for (0..width) |_| try stdout.print("=", .{});
+    try stdout.print("{s}\n\n", .{reset});
     try stdout.flush();
 }

--- a/src/get.zig
+++ b/src/get.zig
@@ -4,6 +4,7 @@ const clap = @import("clap");
 
 const args = @import("args.zig");
 const db = @import("database.zig");
+const logging = @import("log.zig");
 const types = @import("types.zig");
 const table = @import("table.zig");
 
@@ -32,7 +33,7 @@ pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Itera
         .OUTPUT = clap.parsers.enumeration(types.Output),
         .STR = clap.parsers.string,
         .PATH = clap.parsers.string,
-        .LEVEL = clap.parsers.enumeration(types.Level),
+        .LEVEL = clap.parsers.enumeration(logging.Level),
     };
 
     // Initialize our diagnostics, which can be used for reporting useful errors.
@@ -55,7 +56,6 @@ pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Itera
     var output = types.Output.tty;
     var database: []const u8 = &[_]u8{};
     var label: []const u8 = &[_]u8{};
-    var level = types.Level.warn;
     var exclude: ?[]const []const u8 = null;
 
     if (res.args.help != 0)
@@ -86,19 +86,12 @@ pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Itera
     }
 
     if (res.args.@"log-level") |l| {
-        level = l;
+        logging.setLogLevel(l);
     }
 
     if (res.args.exclude.len > 0) {
         exclude = res.args.exclude;
     }
-
-    // switch (level) {
-    //    .debug => log_level = std.log.Level.debug,
-    //   .@"error" => log_level = std.log.Level.err,
-    //  .info => log_level = std.log.Level.info,
-    // .warn => log_level = std.log.Level.warn,
-    // }
     const config = types.Config{
         .namespace = namespace,
         .all = allNamespaces,
@@ -107,7 +100,6 @@ pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Itera
         .output = output,
         .database = database,
         .label = label,
-        .logLevel = level,
         .timestamp = std.Io.Timestamp.now(io, .real).toSeconds(),
     };
 

--- a/src/get.zig
+++ b/src/get.zig
@@ -1,0 +1,305 @@
+const std = @import("std");
+
+const clap = @import("clap");
+
+const args = @import("args.zig");
+const db = @import("database.zig");
+const types = @import("types.zig");
+const table = @import("table.zig");
+
+pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iterator, main_args: args.MainArgs) !void {
+    _ = main_args;
+
+    var stdout_buf: [4096]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buf);
+    const stdout = &stdout_writer.interface;
+    // First we specify what parameters our program can take.
+    // We can use `parseParamsComptime` to parse a string into an array of `Param(Help)`.
+    const params = comptime clap.parseParamsComptime(
+        \\-h, --help             Display this help and exit.
+        \\-n, --namespace <STR>   Namespace to get resources from.
+        \\-A, --all-namespaces If present, list all objects across all namespaces. Specifing --namespace will be ignored.
+        \\-s, --sort Prints the resources in order.
+        \\-e, --exclude <STR>... Exclude crd types. Multiple can be excluded eg: "-e <CRD> -e <CRD>"
+        \\-o, --output <OUTPUT> Changes the output format of the results. [default: tty, tty|json|sqlite]
+        \\-d, --database <PATH> Path to the sqlite file to save the results. If the files does not exist it will be created.
+        \\-l, --label <STR> Set the label that will be saved with entries when using the --database option.
+        \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Defualt level is warn.
+        \\
+    );
+
+    const parsers = comptime .{
+        .OUTPUT = clap.parsers.enumeration(types.Output),
+        .STR = clap.parsers.string,
+        .PATH = clap.parsers.string,
+        .LEVEL = clap.parsers.enumeration(types.Level),
+    };
+
+    // Initialize our diagnostics, which can be used for reporting useful errors.
+    // This is optional. You can also pass `.{}` to `clap.parse` if you don't
+    // care about the extra information `Diagnostic` provides.
+    var diag = clap.Diagnostic{};
+    var res = clap.parseEx(clap.Help, &params, parsers, iter, .{
+        .diagnostic = &diag,
+        .allocator = gpa,
+    }) catch |err| {
+        // Report useful error and exit.
+        try diag.reportToFile(io, .stderr(), err);
+        return err;
+    };
+    defer res.deinit();
+
+    var namespace: []const u8 = &[_]u8{};
+    var allNamespaces = false;
+    var sort = false;
+    var output = types.Output.tty;
+    var database: []const u8 = &[_]u8{};
+    var label: []const u8 = &[_]u8{};
+    var level = types.Level.warn;
+    var exclude: ?[]const []const u8 = null;
+
+    if (res.args.help != 0)
+        return clap.helpToFile(io, .stdout(), clap.Help, &params, .{});
+
+    if (res.args.namespace) |n| {
+        namespace = n;
+    }
+
+    if (res.args.@"all-namespaces" == 1) {
+        allNamespaces = true;
+    }
+
+    if (res.args.sort == 1) {
+        sort = true;
+    }
+
+    if (res.args.output) |o| {
+        output = o;
+    }
+
+    if (res.args.database) |d| {
+        database = d;
+    }
+
+    if (res.args.label) |l| {
+        label = l;
+    }
+
+    if (res.args.@"log-level") |l| {
+        level = l;
+    }
+
+    if (res.args.exclude.len > 0) {
+        exclude = res.args.exclude;
+    }
+
+    // switch (level) {
+    //    .debug => log_level = std.log.Level.debug,
+    //   .@"error" => log_level = std.log.Level.err,
+    //  .info => log_level = std.log.Level.info,
+    // .warn => log_level = std.log.Level.warn,
+    // }
+    const config = types.Config{
+        .namespace = namespace,
+        .all = allNamespaces,
+        .sort = sort,
+        .exclude = exclude,
+        .output = output,
+        .database = database,
+        .label = label,
+        .logLevel = level,
+        .timestamp = std.Io.Timestamp.now(io, .real).toSeconds(),
+    };
+
+    std.log.debug("{f}", .{config});
+
+    var crdTypes = getCrdList(io, gpa) catch |err| switch (err) {
+        error.BadExit => {
+            std.log.err("Kubectl returned a none zero exit code", .{});
+            std.process.exit(1);
+        },
+        else => return err,
+    };
+    defer {
+        for (crdTypes.items) |item| {
+            gpa.free(item);
+        }
+        crdTypes.deinit(gpa);
+    }
+
+    if (config.sort) {
+        std.mem.sort([]const u8, crdTypes.items, {}, compareStrings);
+    }
+
+    if (config.output == .sqlite) {
+        if (config.database.len == 0) {
+            std.log.err("--database must be set to use output type of sqlite", .{});
+            std.process.exit(1);
+        }
+        try db.init(config.database);
+    }
+    std.log.info("Total number of CRD types found {}.", .{crdTypes.items.len});
+    var map: ?std.StringHashMap(types.ResourceList) = null;
+    defer if (map) |*m| {
+        var it = m.keyIterator();
+        while (it.next()) |key| {
+            const value = m.get(key.*);
+            if (value) |v| v.deinit(gpa);
+        }
+        m.deinit();
+    };
+    if (config.output == .json) {
+        map = std.StringHashMap(types.ResourceList).init(gpa);
+        const v: u32 = if (crdTypes.items.len <= std.math.maxInt(u32)) @intCast(crdTypes.items.len) else std.math.maxInt(u32);
+        if (map) |*m| try m.ensureTotalCapacity(v);
+    }
+    for (crdTypes.items) |line| {
+        if (contains(config.exclude, line)) {
+            std.log.debug("filter out: {s}", .{line});
+
+            continue;
+        }
+
+        const resource = getCRJson(io, gpa, config, line) catch |err| switch (err) {
+            error.NoData => {
+                continue;
+            },
+            else => return err,
+        };
+        switch (config.output) {
+            .tty => {
+                defer {
+                    resource.deinit(gpa);
+                }
+                try table.print(io, resource);
+            },
+            .sqlite => {
+                defer {
+                    resource.deinit(gpa);
+                }
+                try db.add(resource, config.label, config.timestamp);
+            },
+            .json => {
+                if (map) |*m| {
+                    try m.put(line, resource);
+                }
+            },
+        }
+    }
+
+    if (map) |*m| {
+        std.log.debug("map length: {}", .{m.count()});
+        try stdout.print("{{", .{});
+
+        var it = m.iterator();
+        var count: usize = 1;
+        while (it.next()) |key| {
+            const item = key.value_ptr;
+            const text = try item.toJson(gpa);
+            defer gpa.free(text);
+            try stdout.print("\"{s}\": {s}", .{ key.key_ptr.*, text });
+            if (count < m.count()) {
+                try stdout.print(",", .{});
+                count += 1;
+            }
+        }
+
+        try stdout.print("}}\n", .{});
+        try stdout.flush();
+    }
+}
+
+fn contains(haystack: ?[]const []const u8, needle: []const u8) bool {
+    if (haystack) |stack| {
+        for (stack) |s| {
+            if (std.mem.eql(u8, s, needle)) return true;
+        }
+    }
+
+    return false;
+}
+
+fn getCRJson(io: std.Io, allocator: std.mem.Allocator, config: types.Config, crd: []const u8) !types.ResourceList {
+    const initialcmd = &[_][]const u8{ "kubectl", "get", "--ignore-not-found", crd, "--output", "json" };
+
+    var cmd: std.ArrayList([]const u8) = .empty;
+    defer cmd.deinit(allocator);
+
+    try cmd.appendSlice(allocator, initialcmd);
+    if (config.all) {
+        try cmd.append(allocator, "--all-namespaces");
+    } else {
+        try cmd.append(allocator, "--namespace");
+        try cmd.append(allocator, config.namespace);
+    }
+
+    const ownedCmd = try cmd.toOwnedSlice(allocator);
+    defer allocator.free(ownedCmd);
+
+    const result = std.process.run(allocator, io, .{
+        .argv = ownedCmd,
+    }) catch |err| {
+        std.log.err("Failed to run kubectl: {}", .{err});
+        return err;
+    };
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    if (result.term.exited != 0) {
+        return error.BadExit;
+    }
+
+    if (result.stdout.len == 0) {
+        return error.NoData;
+    }
+
+    const parsed: std.json.Parsed(types.ResourceList) = std.json.parseFromSlice(types.ResourceList, allocator, result.stdout, .{ .ignore_unknown_fields = true }) catch |err| switch (err) {
+        std.json.ParseFromValueError.MissingField => return error.NotFound,
+        else => return err,
+    };
+
+    defer {
+        parsed.deinit();
+    }
+
+    return parsed.value.clone(allocator);
+}
+
+fn compareStrings(_: void, lhs: []const u8, rhs: []const u8) bool {
+    return std.mem.lessThan(u8, lhs, rhs);
+}
+
+fn getCrdList(io: std.Io, allocator: std.mem.Allocator) !std.ArrayList([]const u8) {
+    const cmd = [_][]const u8{ "kubectl", "api-resources", "--verbs=list", "--namespaced", "-o", "name" };
+    const result = std.process.run(allocator, io, .{
+        .argv = &cmd,
+    }) catch |err| {
+        std.log.err("Failed to run kubectl: {}", .{err});
+        return err;
+    };
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    if (result.term.exited != 0) {
+        std.log.debug("stdout: {s}. stderr: {s}", .{ result.stdout, result.stdout });
+        return error.BadExit;
+    }
+    var lines: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (lines.items) |item| {
+            allocator.free(item);
+        }
+        lines.deinit(allocator);
+    }
+
+    var iter = std.mem.splitScalar(u8, result.stdout, '\n');
+    while (iter.next()) |line| {
+        if (line.len > 0) {
+            const owned = try allocator.dupe(u8, line);
+            errdefer allocator.free(owned);
+            try lines.append(allocator, owned);
+        }
+    }
+
+    return lines;
+}

--- a/src/get.zig
+++ b/src/get.zig
@@ -146,9 +146,8 @@ pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Itera
         if (map) |*m| try m.ensureTotalCapacity(v);
     }
     for (crdTypes.items) |line| {
-        if (contains(config.exclude, line)) {
-            std.log.debug("filter out: {s}", .{line});
-
+        if (matchedExclude(config.exclude, line)) |matched| {
+            std.log.debug("excluding resource {s} matched by -e {s}", .{ line, matched });
             continue;
         }
 
@@ -158,6 +157,13 @@ pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Itera
             },
             else => return err,
         };
+        if (resource.items.len > 0) {
+            if (matchedExclude(config.exclude, resource.items[0].kind)) |matched| {
+                std.log.debug("excluding {s}/{s} matched by -e {s}", .{ resource.items[0].apiVersion, resource.items[0].kind, matched });
+                resource.deinit(gpa);
+                continue;
+            }
+        }
         switch (config.output) {
             .tty => {
                 defer {
@@ -201,14 +207,13 @@ pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Itera
     }
 }
 
-fn contains(haystack: ?[]const []const u8, needle: []const u8) bool {
+fn matchedExclude(haystack: ?[]const []const u8, needle: []const u8) ?[]const u8 {
     if (haystack) |stack| {
         for (stack) |s| {
-            if (std.mem.eql(u8, s, needle)) return true;
+            if (std.ascii.eqlIgnoreCase(s, needle)) return s;
         }
     }
-
-    return false;
+    return null;
 }
 
 fn getCRJson(io: std.Io, allocator: std.mem.Allocator, config: types.Config, crd: []const u8) !types.ResourceList {

--- a/src/get.zig
+++ b/src/get.zig
@@ -2,14 +2,13 @@ const std = @import("std");
 
 const clap = @import("clap");
 
-const args = @import("args.zig");
 const db = @import("database.zig");
 const logging = @import("log.zig");
 const types = @import("types.zig");
 const table = @import("table.zig");
+const utils = @import("utils.zig");
 
-pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iterator, main_args: args.MainArgs) !void {
-    _ = main_args;
+pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
 
     var stdout_buf: [4096]u8 = undefined;
     var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buf);
@@ -19,13 +18,13 @@ pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Itera
     const params = comptime clap.parseParamsComptime(
         \\-h, --help             Display this help and exit.
         \\-n, --namespace <STR>   Namespace to get resources from.
-        \\-A, --all-namespaces If present, list all objects across all namespaces. Specifing --namespace will be ignored.
+        \\-A, --all-namespaces If present, list all objects across all namespaces. Specifying --namespace will be ignored.
         \\-s, --sort Prints the resources in order.
         \\-e, --exclude <STR>... Exclude crd types. Multiple can be excluded eg: "-e <CRD> -e <CRD>"
         \\-o, --output <OUTPUT> Changes the output format of the results. [default: tty, tty|json|sqlite]
         \\-d, --database <PATH> Path to the sqlite file to save the results. If the files does not exist it will be created.
         \\-l, --label <STR> Set the label that will be saved with entries when using the --database option.
-        \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Defualt level is warn.
+        \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Default level is warn.
         \\
     );
 
@@ -146,7 +145,7 @@ pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Itera
         if (map) |*m| try m.ensureTotalCapacity(v);
     }
     for (crdTypes.items) |line| {
-        if (matchedExclude(config.exclude, line)) |matched| {
+        if (utils.matchedExclude(config.exclude, line)) |matched| {
             std.log.debug("excluding resource {s} matched by -e {s}", .{ line, matched });
             continue;
         }
@@ -158,7 +157,7 @@ pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Itera
             else => return err,
         };
         if (resource.items.len > 0) {
-            if (matchedExclude(config.exclude, resource.items[0].kind)) |matched| {
+            if (utils.matchedExclude(config.exclude, resource.items[0].kind)) |matched| {
                 std.log.debug("excluding {s}/{s} matched by -e {s}", .{ resource.items[0].apiVersion, resource.items[0].kind, matched });
                 resource.deinit(gpa);
                 continue;
@@ -205,15 +204,6 @@ pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Itera
         try stdout.print("}}\n", .{});
         try stdout.flush();
     }
-}
-
-fn matchedExclude(haystack: ?[]const []const u8, needle: []const u8) ?[]const u8 {
-    if (haystack) |stack| {
-        for (stack) |s| {
-            if (std.ascii.eqlIgnoreCase(s, needle)) return s;
-        }
-    }
-    return null;
 }
 
 fn getCRJson(io: std.Io, allocator: std.mem.Allocator, config: types.Config, crd: []const u8) !types.ResourceList {
@@ -278,7 +268,7 @@ fn getCrdList(io: std.Io, allocator: std.mem.Allocator) !std.ArrayList([]const u
     defer allocator.free(result.stderr);
 
     if (result.term.exited != 0) {
-        std.log.debug("stdout: {s}. stderr: {s}", .{ result.stdout, result.stdout });
+        std.log.debug("stdout: {s}. stderr: {s}", .{ result.stdout, result.stderr });
         return error.BadExit;
     }
     var lines: std.ArrayList([]const u8) = .empty;

--- a/src/log.zig
+++ b/src/log.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub const Level = enum { info, debug, @"error", warn };
 
-pub var log_level: std.log.Level = .info;
+pub var log_level: std.log.Level = .warn;
 
 pub fn setLogLevel(level: Level) void {
     log_level = switch (level) {

--- a/src/log.zig
+++ b/src/log.zig
@@ -1,0 +1,31 @@
+const std = @import("std");
+
+pub const Level = enum { info, debug, @"error", warn };
+
+pub var log_level: std.log.Level = .info;
+
+pub fn setLogLevel(level: Level) void {
+    log_level = switch (level) {
+        .debug => .debug,
+        .info => .info,
+        .warn => .warn,
+        .@"error" => .err,
+    };
+}
+
+pub fn log(
+    comptime level: std.log.Level,
+    comptime scope: @EnumLiteral(),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    const prefix = comptime blk: {
+        if (scope == .default)
+            break :blk "[" ++ level.asText() ++ "] ";
+        break :blk "[" ++ level.asText() ++ "][" ++ @tagName(scope) ++ "] ";
+    };
+
+    if (@intFromEnum(level) <= @intFromEnum(log_level)) {
+        std.debug.print(prefix ++ format ++ "\n", args);
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,31 +8,12 @@ const table = @import("table.zig");
 const arg = @import("args.zig");
 const diff = @import("diff.zig");
 const get = @import("get.zig");
+const logging = @import("log.zig");
 
 pub const std_options: std.Options = .{
-    // Keep compile-time logging permissive; runtime filter in `log`.
     .log_level = .debug,
-    .logFn = log,
+    .logFn = logging.log,
 };
-
-pub var log_level: std.log.Level = .info;
-
-pub fn log(
-    comptime level: std.log.Level,
-    comptime scope: @EnumLiteral(),
-    comptime format: []const u8,
-    args: anytype,
-) void {
-    const prefix = comptime blk: {
-        if (scope == .default)
-            break :blk "[" ++ level.asText() ++ "] ";
-        break :blk "[" ++ level.asText() ++ "][" ++ @tagName(scope) ++ "] ";
-    };
-
-    if (@intFromEnum(level) <= @intFromEnum(log_level)) {
-        std.debug.print(prefix ++ format ++ "\n", args);
-    }
-}
 
 pub fn main(init: std.process.Init) !void {
     var iter = try init.minimal.args.iterateAllocator(init.gpa);
@@ -59,15 +40,8 @@ pub fn main(init: std.process.Init) !void {
         std.process.exit(0);
     }
 
-    var level = types.Level.warn;
     if (res.args.@"log-level") |l| {
-        level = l;
-    }
-    switch (level) {
-        .debug => log_level = std.log.Level.debug,
-        .@"error" => log_level = std.log.Level.err,
-        .info => log_level = std.log.Level.info,
-        .warn => log_level = std.log.Level.warn,
+        logging.setLogLevel(l);
     }
 
     const command = res.positionals[0] orelse {

--- a/src/main.zig
+++ b/src/main.zig
@@ -173,8 +173,8 @@ pub fn main(init: std.process.Init) !void {
     defer if (map) |*m| {
         var it = m.keyIterator();
         while (it.next()) |key| {
-            const value = m.get(key.*).?;
-            value.deinit(allocator);
+            const value = m.get(key.*);
+            if (value) |v| v.deinit(allocator);
         }
         m.deinit();
     };

--- a/src/main.zig
+++ b/src/main.zig
@@ -49,7 +49,7 @@ pub fn main(init: std.process.Init) !void {
         return error.MissingCommand;
     };
     switch (command) {
-        .get => try get.getMain(init.io, init.gpa, &iter, res),
-        .diff => try diff.diffMain(init.io, init.gpa, &iter, res),
+        .get => try get.getMain(init.io, init.gpa, &iter),
+        .diff => try diff.diffMain(init.io, init.gpa, &iter),
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,6 +5,9 @@ const build_options = @import("build_options");
 const db = @import("database.zig");
 const types = @import("types.zig");
 const table = @import("table.zig");
+const arg = @import("args.zig");
+const diff = @import("diff.zig");
+const get = @import("get.zig");
 
 pub const std_options: std.Options = .{
     // Keep compile-time logging permissive; runtime filter in `log`.
@@ -32,304 +35,47 @@ pub fn log(
 }
 
 pub fn main(init: std.process.Init) !void {
-    const allocator = init.gpa;
+    var iter = try init.minimal.args.iterateAllocator(init.gpa);
+    defer iter.deinit();
 
-    var stdout_buf: [4096]u8 = undefined;
-    var stdout_writer = std.Io.File.stdout().writer(init.io, &stdout_buf);
-    const stdout = &stdout_writer.interface;
-    // First we specify what parameters our program can take.
-    // We can use `parseParamsComptime` to parse a string into an array of `Param(Help)`.
-    const params = comptime clap.parseParamsComptime(
-        \\-h, --help             Display this help and exit.
-        \\-n, --namespace <STR>   Namespace to get resources from.
-        \\-A, --all-namespaces If present, list all objects across all namespaces. Specifing --namespace will be ignored.
-        \\-s, --sort Prints the resources in order.
-        \\-e, --exclude <STR>... Exclude crd types. Multiple can be excluded eg: "-e <CRD> -e <CRD>"
-        \\-o, --output <OUTPUT> Changes the output format of the results. [default: tty, tty|json|sqlite]
-        \\-d, --database <PATH> Path to the sqlite file to save the results. If the files does not exist it will be created.
-        \\-l, --label <STR> Set the label that will be saved with entries when using the --database option.
-        \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Defualt level is warn.
-        \\--version Display verson, and exit.
-        \\
-    );
+    _ = iter.next();
 
-    const parsers = comptime .{
-        .OUTPUT = clap.parsers.enumeration(types.Output),
-        .STR = clap.parsers.string,
-        .PATH = clap.parsers.string,
-        .LEVEL = clap.parsers.enumeration(types.Level),
-    };
-
-    // Initialize our diagnostics, which can be used for reporting useful errors.
-    // This is optional. You can also pass `.{}` to `clap.parse` if you don't
-    // care about the extra information `Diagnostic` provides.
     var diag = clap.Diagnostic{};
-    var res = clap.parse(clap.Help, &params, parsers, init.minimal.args, .{
+    var res = clap.parseEx(clap.Help, &arg.main_params, arg.main_parsers, &iter, .{
+        .allocator = init.gpa,
         .diagnostic = &diag,
-        .allocator = allocator,
+        .terminating_positional = 0,
     }) catch |err| {
-        // Report useful error and exit.
         try diag.reportToFile(init.io, .stderr(), err);
         return err;
     };
     defer res.deinit();
 
-    var namespace: []const u8 = &[_]u8{};
-    var allNamespaces = false;
-    var sort = false;
-    var output = types.Output.tty;
-    var database: []const u8 = &[_]u8{};
-    var label: []const u8 = &[_]u8{};
-    var level = types.Level.warn;
-    var exclude: ?[]const []const u8 = null;
-
     if (res.args.help != 0)
-        return clap.helpToFile(init.io, .stdout(), clap.Help, &params, .{});
+        return clap.helpToFile(init.io, .stdout(), clap.Help, &arg.main_params, .{});
 
     if (res.args.version != 0) {
         std.log.info("{s}, {s}", .{ build_options.name, build_options.version });
         std.process.exit(0);
     }
 
-    if (res.args.namespace) |n| {
-        namespace = n;
-    }
-
-    if (res.args.@"all-namespaces" == 1) {
-        allNamespaces = true;
-    }
-
-    if (res.args.sort == 1) {
-        sort = true;
-    }
-
-    if (res.args.output) |o| {
-        output = o;
-    }
-
-    if (res.args.database) |d| {
-        database = d;
-    }
-
-    if (res.args.label) |l| {
-        label = l;
-    }
-
+    var level = types.Level.warn;
     if (res.args.@"log-level") |l| {
         level = l;
     }
-
-    if (res.args.exclude.len > 0) {
-        exclude = res.args.exclude;
-    }
-
     switch (level) {
         .debug => log_level = std.log.Level.debug,
         .@"error" => log_level = std.log.Level.err,
         .info => log_level = std.log.Level.info,
         .warn => log_level = std.log.Level.warn,
     }
-    const config = types.Config{
-        .namespace = namespace,
-        .all = allNamespaces,
-        .sort = sort,
-        .exclude = exclude,
-        .output = output,
-        .database = database,
-        .label = label,
-        .logLevel = level,
-        .timestamp = std.Io.Timestamp.now(init.io, .real).toSeconds(),
+
+    const command = res.positionals[0] orelse {
+        try clap.helpToFile(init.io, .stdout(), clap.Help, &arg.main_params, .{});
+        return error.MissingCommand;
     };
-
-    std.log.debug("{f}", .{config});
-
-    var crdTypes = getCrdList(init.io, allocator) catch |err| switch (err) {
-        error.BadExit => {
-            std.log.err("Kubectl returned a none zero exit code", .{});
-            std.process.exit(1);
-        },
-        else => return err,
-    };
-    defer {
-        for (crdTypes.items) |item| {
-            allocator.free(item);
-        }
-        crdTypes.deinit(allocator);
+    switch (command) {
+        .get => try get.getMain(init.io, init.gpa, &iter, res),
+        .diff => try diff.diffMain(init.io, init.gpa, &iter, res),
     }
-
-    if (config.sort) {
-        std.mem.sort([]const u8, crdTypes.items, {}, compareStrings);
-    }
-
-    if (config.output == .sqlite) {
-        if (config.database.len == 0) {
-            std.log.err("--database must be set to use output type of sqlite", .{});
-            std.process.exit(1);
-        }
-        try db.init(config.database);
-    }
-    std.log.info("Total number of CRD types found {}.", .{crdTypes.items.len});
-    var map: ?std.StringHashMap(types.ResourceList) = null;
-    defer if (map) |*m| {
-        var it = m.keyIterator();
-        while (it.next()) |key| {
-            const value = m.get(key.*);
-            if (value) |v| v.deinit(allocator);
-        }
-        m.deinit();
-    };
-    if (config.output == .json) {
-        map = std.StringHashMap(types.ResourceList).init(allocator);
-        const v: u32 = if (crdTypes.items.len <= std.math.maxInt(u32)) @intCast(crdTypes.items.len) else std.math.maxInt(u32);
-        if (map) |*m| try m.ensureTotalCapacity(v);
-    }
-    for (crdTypes.items) |line| {
-        if (contains(config.exclude, line)) {
-            std.log.debug("filter out: {s}", .{line});
-
-            continue;
-        }
-
-        const resource = getCRJson(init.io, allocator, config, line) catch |err| switch (err) {
-            error.NoData => {
-                continue;
-            },
-            else => return err,
-        };
-        switch (config.output) {
-            .tty => {
-                defer {
-                    resource.deinit(allocator);
-                }
-                try table.print(init.io, resource);
-            },
-            .sqlite => {
-                defer {
-                    resource.deinit(allocator);
-                }
-                try db.add(resource, config.label, config.timestamp);
-            },
-            .json => {
-                if (map) |*m| {
-                    try m.put(line, resource);
-                }
-            },
-        }
-    }
-
-    if (map) |*m| {
-        std.log.debug("map length: {}", .{m.count()});
-        try stdout.print("{{", .{});
-
-        var it = m.iterator();
-        var count: usize = 1;
-        while (it.next()) |key| {
-            const item = key.value_ptr;
-            const text = try item.toJson(allocator);
-            defer allocator.free(text);
-            try stdout.print("\"{s}\": {s}", .{ key.key_ptr.*, text });
-            if (count < m.count()) {
-                try stdout.print(",", .{});
-                count += 1;
-            }
-        }
-
-        try stdout.print("}}\n", .{});
-        try stdout.flush();
-    }
-}
-
-fn contains(haystack: ?[]const []const u8, needle: []const u8) bool {
-    if (haystack) |stack| {
-        for (stack) |s| {
-            if (std.mem.eql(u8, s, needle)) return true;
-        }
-    }
-
-    return false;
-}
-
-fn getCRJson(io: std.Io, allocator: std.mem.Allocator, config: types.Config, crd: []const u8) !types.ResourceList {
-    const initialcmd = &[_][]const u8{ "kubectl", "get", "--ignore-not-found", crd, "--output", "json" };
-
-    var cmd: std.ArrayList([]const u8) = .empty;
-    defer cmd.deinit(allocator);
-
-    try cmd.appendSlice(allocator, initialcmd);
-    if (config.all) {
-        try cmd.append(allocator, "--all-namespaces");
-    } else {
-        try cmd.append(allocator, "--namespace");
-        try cmd.append(allocator, config.namespace);
-    }
-
-    const ownedCmd = try cmd.toOwnedSlice(allocator);
-    defer allocator.free(ownedCmd);
-
-    const result = std.process.run(allocator, io, .{
-        .argv = ownedCmd,
-    }) catch |err| {
-        std.log.err("Failed to run kubectl: {}", .{err});
-        return err;
-    };
-    defer allocator.free(result.stdout);
-    defer allocator.free(result.stderr);
-
-    if (result.term.exited != 0) {
-        return error.BadExit;
-    }
-
-    if (result.stdout.len == 0) {
-        return error.NoData;
-    }
-
-    const parsed: std.json.Parsed(types.ResourceList) = std.json.parseFromSlice(types.ResourceList, allocator, result.stdout, .{ .ignore_unknown_fields = true }) catch |err| switch (err) {
-        std.json.ParseFromValueError.MissingField => return error.NotFound,
-        else => return err,
-    };
-
-    defer {
-        parsed.deinit();
-    }
-
-    return parsed.value.clone(allocator);
-}
-
-fn compareStrings(_: void, lhs: []const u8, rhs: []const u8) bool {
-    return std.mem.lessThan(u8, lhs, rhs);
-}
-
-fn getCrdList(io: std.Io, allocator: std.mem.Allocator) !std.ArrayList([]const u8) {
-    const cmd = [_][]const u8{ "kubectl", "api-resources", "--verbs=list", "--namespaced", "-o", "name" };
-    const result = std.process.run(allocator, io, .{
-        .argv = &cmd,
-    }) catch |err| {
-        std.log.err("Failed to run kubectl: {}", .{err});
-        return err;
-    };
-    defer allocator.free(result.stdout);
-    defer allocator.free(result.stderr);
-
-    if (result.term.exited != 0) {
-        std.log.debug("stdout: {s}. stderr: {s}", .{ result.stdout, result.stdout });
-        return error.BadExit;
-    }
-    var lines: std.ArrayList([]const u8) = .empty;
-    errdefer {
-        for (lines.items) |item| {
-            allocator.free(item);
-        }
-        lines.deinit(allocator);
-    }
-
-    var iter = std.mem.splitScalar(u8, result.stdout, '\n');
-    while (iter.next()) |line| {
-        if (line.len > 0) {
-            const owned = try allocator.dupe(u8, line);
-            errdefer allocator.free(owned);
-            try lines.append(allocator, owned);
-        }
-    }
-
-    return lines;
 }

--- a/src/table.zig
+++ b/src/table.zig
@@ -1,36 +1,46 @@
 const std = @import("std");
 const types = @import("types.zig");
 
-pub fn print(io: std.Io, data: types.ResourceList) !void {
-    // TODO: This code is horrible, needs a large refactor
+const title_name = "NAME";
+const title_namespace = "NAMESPACE";
+const title_creationTimestamp = "CREATION TIMESTAMP";
+const header_count = 3;
 
-    var buf: [4096]u8 = undefined;
-    var file_writer = std.Io.File.stdout().writer(io, &buf);
-    const stdout = &file_writer.interface;
-    const title_name = "NAME";
-    const title_namespace = "NAMESPACE";
-    const title_creationTimestamp = "CREATION TIMESTAMP";
-
+fn calcColumnWidths(data: types.ResourceList) [3]usize {
     var max_name_length: usize = title_name.len;
     var max_namespace_length: usize = title_namespace.len;
     var max_creationTimestamp_length: usize = title_creationTimestamp.len;
-    const kind = data.items[0].kind;
+
     for (data.items) |i| {
         if (i.metadata.name.len > max_name_length) max_name_length = i.metadata.name.len;
         if (i.metadata.namespace.len > max_namespace_length) max_namespace_length = i.metadata.namespace.len;
         if (i.metadata.creationTimestamp.len > max_creationTimestamp_length) max_creationTimestamp_length = i.metadata.creationTimestamp.len;
     }
 
-    const headers: [3][]const u8 = .{ title_namespace, title_name, title_creationTimestamp };
-    const spacing: [3]usize = .{ max_namespace_length, max_name_length, max_creationTimestamp_length };
+    return .{ max_namespace_length, max_name_length, max_creationTimestamp_length };
+}
+
+fn calcLineLength(spacing: [3]usize) usize {
     var spacing_required: usize = 0;
     for (spacing) |s| spacing_required += s;
+    return spacing_required + 2 + (2 * header_count) + (header_count - 1) - 1;
+}
 
-    // add 2 for table ends
-    // add 2 for each field printed (name, namespace) = 4
-    // add field count - 1 for vertical divides
-    // needs a - 1 for some reason
-    const line_length = spacing_required + 2 + (2 * headers.len) + (headers.len - 1) - 1;
+pub fn calcWidth(data: types.ResourceList) usize {
+    return calcLineLength(calcColumnWidths(data));
+}
+
+pub fn print(io: std.Io, data: types.ResourceList) !void {
+    // TODO: This code is horrible, needs a large refactor
+
+    var buf: [4096]u8 = undefined;
+    var file_writer = std.Io.File.stdout().writer(io, &buf);
+    const stdout = &file_writer.interface;
+
+    const kind = data.items[0].kind;
+    const headers: [3][]const u8 = .{ title_namespace, title_name, title_creationTimestamp };
+    const spacing = calcColumnWidths(data);
+    const line_length = calcLineLength(spacing);
     var divider_idx: usize = 0;
     var divider = 2 + spacing[divider_idx] + 1;
     divider_idx += 1;
@@ -177,4 +187,43 @@ pub fn print(io: std.Io, data: types.ResourceList) !void {
         }
     }
     try stdout.flush();
+}
+
+fn testResource(name: []const u8, namespace: []const u8, timestamp: []const u8) types.Resource {
+    return .{
+        .kind = "Pod",
+        .apiVersion = "v1",
+        .metadata = .{
+            .name = name,
+            .namespace = namespace,
+            .creationTimestamp = timestamp,
+        },
+    };
+}
+
+test "calcWidth with header-length values" {
+    const items = [_]types.Resource{testResource("ab", "cd", "ef")};
+    const width = calcWidth(.{ .items = &items });
+    // columns default to header lengths: NAMESPACE(9) + NAME(4) + CREATION TIMESTAMP(18) = 31
+    // line_length = 31 + 2 + 6 + 2 - 1 = 40
+    try std.testing.expectEqual(@as(usize, 40), width);
+}
+
+test "calcWidth with longer name expands width" {
+    const items = [_]types.Resource{testResource("a-very-long-resource-name", "default", "2026-01-01T00:00:00Z")};
+    const width = calcWidth(.{ .items = &items });
+    // columns: NAMESPACE(9) + name(25) + timestamp(20) = 54
+    // line_length = 54 + 2 + 6 + 2 - 1 = 63
+    try std.testing.expectEqual(@as(usize, 63), width);
+}
+
+test "calcWidth picks max across multiple items" {
+    const items = [_]types.Resource{
+        testResource("short", "ns", "2026-01-01T00:00:00Z"),
+        testResource("a-much-longer-name", "a-long-namespace", "2026-01-01T00:00:00Z"),
+    };
+    const width = calcWidth(.{ .items = &items });
+    // columns: namespace(16) + name(18) + timestamp(20) = 54
+    // line_length = 54 + 2 + 6 + 2 - 1 = 63
+    try std.testing.expectEqual(@as(usize, 63), width);
 }

--- a/src/types.zig
+++ b/src/types.zig
@@ -39,6 +39,20 @@ pub const Config = struct {
     }
 };
 
+pub const DiffConfig = struct {
+    database: []const u8,
+    label_a: []const u8,
+    label_b: []const u8,
+
+    pub fn format(self: @This(), writer: *std.Io.Writer) std.Io.Writer.Error!void {
+        try writer.print(
+            "Configuration:\n\tdatabase: {s}\n\tlabel A: {s}\n\tlabel B: {s}\n",
+            .{ self.database, self.label_a, self.label_b },
+        );
+        try writer.flush();
+    }
+};
+
 pub const Metadata = struct {
     name: []const u8,
     namespace: []const u8,

--- a/src/types.zig
+++ b/src/types.zig
@@ -43,11 +43,12 @@ pub const DiffConfig = struct {
     database: []const u8,
     label_a: []const u8,
     label_b: []const u8,
+    output: Output,
 
     pub fn format(self: @This(), writer: *std.Io.Writer) std.Io.Writer.Error!void {
         try writer.print(
-            "Configuration:\n\tdatabase: {s}\n\tlabel A: {s}\n\tlabel B: {s}\n",
-            .{ self.database, self.label_a, self.label_b },
+            "Configuration:\n\tdatabase: {s}\n\tlabel A: {s}\n\tlabel B: {s}\n\toutput: {s}\n",
+            .{ self.database, self.label_a, self.label_b, @tagName(self.output) },
         );
         try writer.flush();
     }

--- a/src/types.zig
+++ b/src/types.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 
 pub const Output = enum { tty, json, sqlite };
-pub const Level = enum { info, debug, @"error", warn };
 pub const Bool = enum { true, false };
 
 pub const Config = struct {
@@ -12,7 +11,6 @@ pub const Config = struct {
     output: Output,
     database: []const u8,
     label: []const u8,
-    logLevel: Level,
     timestamp: i64,
 
     pub fn format(self: @This(), writer: *std.Io.Writer) std.Io.Writer.Error!void {
@@ -33,8 +31,8 @@ pub const Config = struct {
         }
 
         try writer.print(
-            "\toutput: {s}\n\tdatabase: {s}\n\tlabel: {s}\n\tlog level: {s}",
-            .{ @tagName(self.output), self.database, self.label, @tagName(self.logLevel) },
+            "\toutput: {s}\n\tdatabase: {s}\n\tlabel: {s}",
+            .{ @tagName(self.output), self.database, self.label },
         );
 
         try writer.flush();

--- a/src/types.zig
+++ b/src/types.zig
@@ -101,7 +101,9 @@ pub const Resource = struct {
         var buffer = try std.ArrayList(u8).initCapacity(allocator, 256);
         defer buffer.deinit(allocator);
 
-        const initial_string = try std.fmt.allocPrint(allocator, "{{\"name\": \"{s}\", \"namespace\": \"{s}\", \"createTimestamp\": \"{s}\"", .{
+        const initial_string = try std.fmt.allocPrint(allocator, "{{\"kind\": \"{s}\", \"apiVersion\": \"{s}\", \"name\": \"{s}\", \"namespace\": \"{s}\", \"creationTimestamp\": \"{s}\"", .{
+            self.kind,
+            self.apiVersion,
             self.metadata.name,
             self.metadata.namespace,
             self.metadata.creationTimestamp,
@@ -110,7 +112,7 @@ pub const Resource = struct {
         defer allocator.free(initial_string);
 
         if (self.metadata.resourceVersion) |version| {
-            const resource_version = try std.fmt.allocPrint(allocator, ", \"resourceVersion\": {s}", .{version});
+            const resource_version = try std.fmt.allocPrint(allocator, ", \"resourceVersion\": \"{s}\"", .{version});
             defer allocator.free(resource_version);
             try buffer.appendSlice(allocator, resource_version);
         }

--- a/src/types.zig
+++ b/src/types.zig
@@ -44,12 +44,25 @@ pub const DiffConfig = struct {
     label_a: []const u8,
     label_b: []const u8,
     output: Output,
+    exclude: ?[]const []const u8 = null,
 
     pub fn format(self: @This(), writer: *std.Io.Writer) std.Io.Writer.Error!void {
         try writer.print(
-            "Configuration:\n\tdatabase: {s}\n\tlabel A: {s}\n\tlabel B: {s}\n\toutput: {s}\n",
+            "Configuration:\n\tdatabase: {s}\n\tlabel A: {s}\n\tlabel B: {s}\n\toutput: {s}\n\texclude: ",
             .{ self.database, self.label_a, self.label_b, @tagName(self.output) },
         );
+
+        if (self.exclude) |items| {
+            try writer.writeAll("[");
+            for (items, 0..) |item, i| {
+                if (i > 0) try writer.writeAll(", ");
+                try writer.print("{s}", .{item});
+            }
+            try writer.writeAll("]\n");
+        } else {
+            try writer.writeAll("null\n");
+        }
+
         try writer.flush();
     }
 };

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+
+pub fn matchedExclude(haystack: ?[]const []const u8, needle: []const u8) ?[]const u8 {
+    if (haystack) |stack| {
+        for (stack) |s| {
+            if (std.ascii.eqlIgnoreCase(s, needle)) return s;
+        }
+    }
+    return null;
+}
+
+test "null haystack returns null" {
+    try std.testing.expectEqual(null, matchedExclude(null, "Pod"));
+}
+
+test "no match returns null" {
+    const haystack = &[_][]const u8{ "Service", "Deployment" };
+    try std.testing.expectEqual(null, matchedExclude(haystack, "ConfigMap"));
+}
+
+test "exact match returns matched string" {
+    const haystack = &[_][]const u8{ "Secret", "Ingress", "Pod" };
+    try std.testing.expectEqualStrings("Ingress", matchedExclude(haystack, "Ingress").?);
+}
+
+test "case-insensitive match" {
+    const haystack = &[_][]const u8{ "deployment", "ReplicaSet" };
+    try std.testing.expectEqualStrings("ReplicaSet", matchedExclude(haystack, "replicaset").?);
+    try std.testing.expectEqualStrings("deployment", matchedExclude(haystack, "DEPLOYMENT").?);
+}
+
+test "different length strings do not match" {
+    const haystack = &[_][]const u8{ "services", "Pod" };
+    try std.testing.expectEqual(null, matchedExclude(haystack, "service"));
+    try std.testing.expectEqual(null, matchedExclude(haystack, "Pods"));
+}
+
+test "returns first match when multiple could match" {
+    const haystack = &[_][]const u8{ "node", "NODE", "Node" };
+    try std.testing.expectEqualStrings("node", matchedExclude(haystack, "Node").?);
+}


### PR DESCRIPTION
Closes #31

# Summary

- Adds a `diff` subcommand that compares two labeled snapshots stored in a SQLite database and categorises resources as added, updated, or removed between labels
- Refactors the CLI from a single-command design into a subcommand architecture (`get` and `diff`)
- Extracts shared concerns into dedicated modules: logging (`log.zig`), argument definitions (`args.zig`), and exclude matching (`utils.zig`)
- Improves the `--exclude` flag to use case-insensitive full-string matching against both CRD resource name and resolved Kind name
- Supports both TTY (table) and JSON output formats for the diff command
- Fixes JSON output to include `kind` and `apiVersion` fields, and properly quotes `resourceVersion`
- Fixes a null pointer issue when `resourceVersion` is absent

# Acceptance Criteria

The issue asks for the ability to compare database results when two labels are passed, showing resources that are in one label but not the other, and printing the table of added or removed resources.

- **Compare results from database with two labels**: The `diff` subcommand accepts two positional `LABEL` arguments and a `--database` flag, querying the SQLite database for differences between the two snapshots.
- **Show resources in one but not the other**: The database layer implements `added_sql` and `deleted_sql` queries using `NOT EXISTS` subqueries to find resources present in one label but missing from the other.
- **Print table of added/removed resources**: TTY output renders three colour-coded sections (Added, Updated, Removed) using the existing table renderer, with consistent column widths across all sections.
- **Beyond the original scope**: The PR also detects updated resources (same identity, different `resourceVersion` or `generation`) and supports JSON output via `--output=json`.

# Test Plan

- [x] Run `diff` with a database containing two labels and verify added, updated, and removed resources appear in the correct sections
- [x] Run `diff --output=json` and verify the JSON blob contains `added`, `updated`, and `deleted` arrays
- [x] Run `diff` with `--exclude` and verify case-insensitive Kind filtering works
- [x] Run `get` subcommand and verify existing functionality is unchanged
- [x] Run `zig build test` to confirm unit tests pass (table width and exclude matching)
- [x] Verify `--help` output at the top level shows `get` and `diff` subcommands
- [x] Verify `diff --help` shows diff-specific flags
