### PR TITLE
Add snapshot command, diff summary, and refactor CLI args

### DIFF
--- a/.changes/unreleased/Added-20260628-211450.yaml
+++ b/.changes/unreleased/Added-20260628-211450.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Snapshot feature allows capturing snapshots of a cluster over time. Results are saved to a database only.
+time: 2026-06-28T21:14:50.344574667+01:00

--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ kubectlgetall -n <namespace>
 There are some flags that can be passed.
 ```shell
 USAGE:
-  kubectlgetall <COMMAND> [FLAGS] 
+  kubectlgetall <COMMAND> [FLAGS]
 
 COMMANDS:
 get                   Get list of resource on cluster.
 diff                  Show the resources Added, Updated and Removed
                       from a cluster by comparing two labels defined in the database.
+snapshot              Take a snapshot of the resouces on the cluster at given intervals.
 
 GLOBAL FLAGS:
 -h, --help            Display this help and exit.

--- a/src/args.zig
+++ b/src/args.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const clap = @import("clap");
 const logging = @import("log.zig");
 const types = @import("types.zig");
@@ -5,6 +6,7 @@ const types = @import("types.zig");
 const SubCommands = enum {
     get,
     diff,
+    snapshot,
 };
 
 pub const main_parsers = .{
@@ -56,5 +58,56 @@ pub const diff_params = clap.parseParamsComptime(
     \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Default level is warn.
     \\<LABEL> Older label used.
     \\<LABEL> Newer label used.
+    \\
+);
+
+pub const snapshot_parsers = .{
+    .PATH = clap.parsers.string,
+    .STR = clap.parsers.string,
+    .LABEL = clap.parsers.string,
+    .LEVEL = clap.parsers.enumeration(logging.Level),
+    .TIME = parseDuration,
+    .INT = clap.parsers.int(u32, 10),
+};
+
+pub const DurationError = error{
+    InvalidDurationFormat,
+    Overflow,
+    InvalidCharacter,
+};
+
+fn parseDuration(in: []const u8) DurationError!u64 {
+    if (in.len == 0) return error.InvalidDurationFormat;
+
+    const last = in[in.len - 1];
+    const multiplier: u64, const digits: []const u8 = switch (last) {
+        's' => .{ 1, in[0 .. in.len - 1] },
+        'm' => .{ 60, in[0 .. in.len - 1] },
+        'h' => .{ 3600, in[0 .. in.len - 1] },
+        '0'...'9' => .{ 1, in },
+        else => return error.InvalidDurationFormat,
+    };
+
+    if (digits.len == 0) return error.InvalidDurationFormat;
+
+    const value = std.fmt.parseUnsigned(u64, digits, 10) catch |err| switch (err) {
+        error.Overflow => return error.Overflow,
+        error.InvalidCharacter => return error.InvalidCharacter,
+    };
+
+    return std.math.mul(u64, value, multiplier) catch return error.Overflow;
+}
+
+pub const snapshot_params = clap.parseParamsComptime(
+    \\-h, --help Display this help and exit.
+    \\-n, --namespace <STR> Namespace to get resources from.
+    \\-A, --all-namespaces If present, list all objects across all namespaces. Specifying --namespace will be ignored.
+    \\-d, --database <PATH> Path to the sqlite file to save the results. If the files does not exist it will be created. [REQUIRED]
+    \\-l, --label <STR> Set the label that will be saved with entries when using the --database option. [REQUIRED]
+    \\--delay <TIME> Time delay between snaphotting the cluster. Format can be INT, or INTs, INTm, INTh. Default time delay of 60, 60s, 1m.
+    \\-c, --count <INT> Number of snapshots to take. Default 0, meaning unlimited.
+    \\--limit <TIME> Max runtime of snapshot. If time limit is reached before the count limit is reached the application will exit. Format can be INT, or INTs, INTm, INTh. Default of time limit of 0, meaning unlimited.
+    \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Default level is warn.
+    \\-e, --exclude <STR>... Exclude resource types. Multiple can be excluded eg: "-e <KIND> -e <KIND>"
     \\
 );

--- a/src/args.zig
+++ b/src/args.zig
@@ -1,5 +1,6 @@
 const clap = @import("clap");
 const logging = @import("log.zig");
+const types = @import("types.zig");
 
 const SubCommands = enum {
     get,
@@ -16,5 +17,44 @@ pub const main_params = clap.parseParamsComptime(
     \\--version Display version, and exit.
     \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Default level is warn.
     \\<command>
+    \\
+);
+
+pub const get_parsers = .{
+    .OUTPUT = clap.parsers.enumeration(types.Output),
+    .STR = clap.parsers.string,
+    .PATH = clap.parsers.string,
+    .LEVEL = clap.parsers.enumeration(logging.Level),
+};
+
+pub const get_params = clap.parseParamsComptime(
+    \\-h, --help             Display this help and exit.
+    \\-n, --namespace <STR>   Namespace to get resources from.
+    \\-A, --all-namespaces If present, list all objects across all namespaces. Specifying --namespace will be ignored.
+    \\-s, --sort Prints the resources in order.
+    \\-e, --exclude <STR>... Exclude crd types. Multiple can be excluded eg: "-e <CRD> -e <CRD>"
+    \\-o, --output <OUTPUT> Changes the output format of the results. [default: tty, tty|json|sqlite]
+    \\-d, --database <PATH> Path to the sqlite file to save the results. If the files does not exist it will be created.
+    \\-l, --label <STR> Set the label that will be saved with entries when using the --database option.
+    \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Default level is warn.
+    \\
+);
+
+pub const diff_parsers = .{
+    .PATH = clap.parsers.string,
+    .STR = clap.parsers.string,
+    .LABEL = clap.parsers.string,
+    .LEVEL = clap.parsers.enumeration(logging.Level),
+    .OUTPUT = clap.parsers.enumeration(types.Output),
+};
+
+pub const diff_params = clap.parseParamsComptime(
+    \\-h, --help Display this help and exit.
+    \\-d, --database <PATH> Path to SQLite database to load data from.
+    \\-e, --exclude <STR>... Exclude resource types. Multiple can be excluded eg: "-e <KIND> -e <KIND>"
+    \\-o, --output <OUTPUT> Changes the output format of the results. [default: tty, tty|json]
+    \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Default level is warn.
+    \\<LABEL> Older label used.
+    \\<LABEL> Newer label used.
     \\
 );

--- a/src/cluster.zig
+++ b/src/cluster.zig
@@ -1,0 +1,92 @@
+const std = @import("std");
+
+const types = @import("types.zig");
+
+pub fn getCrdList(io: std.Io, gpa: std.mem.Allocator) !std.ArrayList([]const u8) {
+    const cmd = [_][]const u8{ "kubectl", "api-resources", "--verbs=list", "--namespaced", "-o", "name" };
+    const result = std.process.run(gpa, io, .{
+        .argv = &cmd,
+    }) catch |err| {
+        std.log.err("Failed to run kubectl: {}", .{err});
+        return err;
+    };
+    defer {
+        gpa.free(result.stdout);
+        gpa.free(result.stderr);
+    }
+
+    if (result.term.exited != 0) {
+        std.log.debug("stdout: {s}. stderr: {s}", .{ result.stdout, result.stderr });
+        return error.BadExit;
+    }
+    var lines: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (lines.items) |item| {
+            gpa.free(item);
+        }
+        lines.deinit(gpa);
+    }
+
+    var iter = std.mem.splitScalar(u8, result.stdout, '\n');
+    while (iter.next()) |line| {
+        if (line.len > 0) {
+            const owned = try gpa.dupe(u8, line);
+            errdefer gpa.free(owned);
+            try lines.append(gpa, owned);
+        }
+    }
+
+    return lines;
+}
+
+pub fn getCRJson(io: std.Io, gpa: std.mem.Allocator, config: anytype, crd: []const u8) !types.ResourceList {
+    const T = @TypeOf(config);
+    comptime {
+        if (!@hasField(T, "all")) @compileError("config type must have an 'all' field");
+        if (!@hasField(T, "namespace")) @compileError("config type must have a 'namespace' field");
+    }
+
+    const initialcmd = &[_][]const u8{ "kubectl", "get", "--ignore-not-found", crd, "--output", "json" };
+
+    var cmd: std.ArrayList([]const u8) = .empty;
+    defer cmd.deinit(gpa);
+
+    try cmd.appendSlice(gpa, initialcmd);
+    if (config.all) {
+        try cmd.append(gpa, "--all-namespaces");
+    } else {
+        try cmd.append(gpa, "--namespace");
+        try cmd.append(gpa, config.namespace);
+    }
+
+    const ownedCmd = try cmd.toOwnedSlice(gpa);
+    defer gpa.free(ownedCmd);
+
+    const result = std.process.run(gpa, io, .{
+        .argv = ownedCmd,
+    }) catch |err| {
+        std.log.err("Failed to run kubectl: {}", .{err});
+        return err;
+    };
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    if (result.term.exited != 0) {
+        return error.BadExit;
+    }
+
+    if (result.stdout.len == 0) {
+        return error.NoData;
+    }
+
+    const parsed: std.json.Parsed(types.ResourceList) = std.json.parseFromSlice(types.ResourceList, gpa, result.stdout, .{ .ignore_unknown_fields = true }) catch |err| switch (err) {
+        std.json.ParseFromValueError.MissingField => return error.NotFound,
+        else => return err,
+    };
+
+    defer {
+        parsed.deinit();
+    }
+
+    return parsed.value.clone(gpa);
+}

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -5,29 +5,11 @@ const db = @import("database.zig");
 const table = @import("table.zig");
 const types = @import("types.zig");
 const help = @import("help.zig");
+const args = @import("args.zig");
 
 pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
-    const params = comptime clap.parseParamsComptime(
-        \\-h, --help Display this help and exit.
-        \\-d, --database <PATH> Path to SQLite database to load data from.
-        \\-e, --exclude <STR>... Exclude resource types. Multiple can be excluded eg: "-e <KIND> -e <KIND>"
-        \\-o, --output <OUTPUT> Changes the output format of the results. [default: tty, tty|json]
-        \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Default level is warn.
-        \\<LABEL> Older label used.
-        \\<LABEL> Newer label used.
-        \\
-    );
-
-    const parsers = comptime .{
-        .PATH = clap.parsers.string,
-        .STR = clap.parsers.string,
-        .LABEL = clap.parsers.string,
-        .LEVEL = clap.parsers.enumeration(logging.Level),
-        .OUTPUT = clap.parsers.enumeration(types.Output),
-    };
-
     var diag = clap.Diagnostic{};
-    var res = clap.parseEx(clap.Help, &params, parsers, iter, .{
+    var res = clap.parseEx(clap.Help, &args.diff_params, args.diff_parsers, iter, .{
         .diagnostic = &diag,
         .allocator = gpa,
     }) catch |err| {

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -52,6 +52,11 @@ pub fn diffMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iter
             try printSection(io, "Added Resources", added_resources, max_width);
             try printSection(io, "Updated Resources", updated_resources, max_width);
             try printSection(io, "Removed Resources", deleted_resources, max_width);
+            try printSummary(io, max_width, .{
+                .added = added_resources,
+                .updated = updated_resources,
+                .deleted = deleted_resources,
+            });
         },
         .json => {
             try printJson(io, gpa, added_resources, updated_resources, deleted_resources);
@@ -74,6 +79,11 @@ fn printJson(io: std.Io, gpa: std.mem.Allocator, added: types.ResourceList, upda
     try printResourceListJson(stdout, gpa, updated);
     try stdout.print(", \"deleted\": ", .{});
     try printResourceListJson(stdout, gpa, deleted);
+    try stdout.print(", \"summary\": {{\"added\": {}, \"updated\": {}, \"deleted\": {}}}", .{
+        added.items.len,
+        updated.items.len,
+        deleted.items.len,
+    });
     try stdout.print("}}\n", .{});
     try stdout.flush();
 }
@@ -146,5 +156,24 @@ fn section(io: std.Io, header: []const u8, width: usize) !void {
     try stdout.print("{s}\n", .{header});
     for (0..width) |_| try stdout.print("=", .{});
     try stdout.print("{s}\n\n", .{reset});
+    try stdout.flush();
+}
+
+const values = struct {
+    added: types.ResourceList,
+    updated: types.ResourceList,
+    deleted: types.ResourceList,
+};
+
+fn printSummary(io: std.Io, width: usize, value: values) !void {
+    try section(io, "Summary", width);
+
+    var buf: [4096]u8 = undefined;
+    var file_writer = std.Io.File.stdout().writer(io, &buf);
+    const stdout = &file_writer.interface;
+
+    try stdout.print("Added: {}\n", .{value.added.items.len});
+    try stdout.print("Updated: {}\n", .{value.updated.items.len});
+    try stdout.print("Removed: {}\n", .{value.deleted.items.len});
     try stdout.flush();
 }

--- a/src/get.zig
+++ b/src/get.zig
@@ -8,38 +8,15 @@ const types = @import("types.zig");
 const table = @import("table.zig");
 const utils = @import("utils.zig");
 const help = @import("help.zig");
+const args = @import("args.zig");
 
 pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
     var stdout_buf: [4096]u8 = undefined;
     var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buf);
     const stdout = &stdout_writer.interface;
-    // First we specify what parameters our program can take.
-    // We can use `parseParamsComptime` to parse a string into an array of `Param(Help)`.
-    const params = comptime clap.parseParamsComptime(
-        \\-h, --help             Display this help and exit.
-        \\-n, --namespace <STR>   Namespace to get resources from.
-        \\-A, --all-namespaces If present, list all objects across all namespaces. Specifying --namespace will be ignored.
-        \\-s, --sort Prints the resources in order.
-        \\-e, --exclude <STR>... Exclude crd types. Multiple can be excluded eg: "-e <CRD> -e <CRD>"
-        \\-o, --output <OUTPUT> Changes the output format of the results. [default: tty, tty|json|sqlite]
-        \\-d, --database <PATH> Path to the sqlite file to save the results. If the files does not exist it will be created.
-        \\-l, --label <STR> Set the label that will be saved with entries when using the --database option.
-        \\--log-level <LEVEL> Set the log level. All logs are saved to file. Possible values are (debug, info, warn, error). Default level is warn.
-        \\
-    );
 
-    const parsers = comptime .{
-        .OUTPUT = clap.parsers.enumeration(types.Output),
-        .STR = clap.parsers.string,
-        .PATH = clap.parsers.string,
-        .LEVEL = clap.parsers.enumeration(logging.Level),
-    };
-
-    // Initialize our diagnostics, which can be used for reporting useful errors.
-    // This is optional. You can also pass `.{}` to `clap.parse` if you don't
-    // care about the extra information `Diagnostic` provides.
     var diag = clap.Diagnostic{};
-    var res = clap.parseEx(clap.Help, &params, parsers, iter, .{
+    var res = clap.parseEx(clap.Help, &args.get_params, args.get_parsers, iter, .{
         .diagnostic = &diag,
         .allocator = gpa,
     }) catch |err| {

--- a/src/get.zig
+++ b/src/get.zig
@@ -9,6 +9,7 @@ const table = @import("table.zig");
 const utils = @import("utils.zig");
 const help = @import("help.zig");
 const args = @import("args.zig");
+const cluster = @import("cluster.zig");
 
 pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
     var stdout_buf: [4096]u8 = undefined;
@@ -83,7 +84,7 @@ pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Itera
 
     std.log.debug("{f}", .{config});
 
-    var crdTypes = getCrdList(io, gpa) catch |err| switch (err) {
+    var crdTypes = cluster.getCrdList(io, gpa) catch |err| switch (err) {
         error.BadExit => {
             std.log.err("Kubectl returned a none zero exit code", .{});
             std.process.exit(1);
@@ -98,7 +99,7 @@ pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Itera
     }
 
     if (config.sort) {
-        std.mem.sort([]const u8, crdTypes.items, {}, compareStrings);
+        std.mem.sort([]const u8, crdTypes.items, {}, utils.compareStrings);
     }
 
     if (config.output == .sqlite) {
@@ -129,7 +130,7 @@ pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Itera
             continue;
         }
 
-        const resource = getCRJson(io, gpa, config, line) catch |err| switch (err) {
+        const resource = cluster.getCRJson(io, gpa, config, line) catch |err| switch (err) {
             error.NoData => {
                 continue;
             },
@@ -183,91 +184,4 @@ pub fn getMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Itera
         try stdout.print("}}\n", .{});
         try stdout.flush();
     }
-}
-
-fn getCRJson(io: std.Io, allocator: std.mem.Allocator, config: types.Config, crd: []const u8) !types.ResourceList {
-    const initialcmd = &[_][]const u8{ "kubectl", "get", "--ignore-not-found", crd, "--output", "json" };
-
-    var cmd: std.ArrayList([]const u8) = .empty;
-    defer cmd.deinit(allocator);
-
-    try cmd.appendSlice(allocator, initialcmd);
-    if (config.all) {
-        try cmd.append(allocator, "--all-namespaces");
-    } else {
-        try cmd.append(allocator, "--namespace");
-        try cmd.append(allocator, config.namespace);
-    }
-
-    const ownedCmd = try cmd.toOwnedSlice(allocator);
-    defer allocator.free(ownedCmd);
-
-    const result = std.process.run(allocator, io, .{
-        .argv = ownedCmd,
-    }) catch |err| {
-        std.log.err("Failed to run kubectl: {}", .{err});
-        return err;
-    };
-    defer allocator.free(result.stdout);
-    defer allocator.free(result.stderr);
-
-    if (result.term.exited != 0) {
-        return error.BadExit;
-    }
-
-    if (result.stdout.len == 0) {
-        return error.NoData;
-    }
-
-    const parsed: std.json.Parsed(types.ResourceList) = std.json.parseFromSlice(types.ResourceList, allocator, result.stdout, .{ .ignore_unknown_fields = true }) catch |err| switch (err) {
-        std.json.ParseFromValueError.MissingField => return error.NotFound,
-        else => return err,
-    };
-
-    defer {
-        parsed.deinit();
-    }
-
-    return parsed.value.clone(allocator);
-}
-
-fn compareStrings(_: void, lhs: []const u8, rhs: []const u8) bool {
-    return std.mem.lessThan(u8, lhs, rhs);
-}
-
-fn getCrdList(io: std.Io, gpa: std.mem.Allocator) !std.ArrayList([]const u8) {
-    const cmd = [_][]const u8{ "kubectl", "api-resources", "--verbs=list", "--namespaced", "-o", "name" };
-    const result = std.process.run(gpa, io, .{
-        .argv = &cmd,
-    }) catch |err| {
-        std.log.err("Failed to run kubectl: {}", .{err});
-        return err;
-    };
-    defer {
-        gpa.free(result.stdout);
-        gpa.free(result.stderr);
-    }
-
-    if (result.term.exited != 0) {
-        std.log.debug("stdout: {s}. stderr: {s}", .{ result.stdout, result.stderr });
-        return error.BadExit;
-    }
-    var lines: std.ArrayList([]const u8) = .empty;
-    errdefer {
-        for (lines.items) |item| {
-            gpa.free(item);
-        }
-        lines.deinit(gpa);
-    }
-
-    var iter = std.mem.splitScalar(u8, result.stdout, '\n');
-    while (iter.next()) |line| {
-        if (line.len > 0) {
-            const owned = try gpa.dupe(u8, line);
-            errdefer gpa.free(owned);
-            try lines.append(gpa, owned);
-        }
-    }
-
-    return lines;
 }

--- a/src/help.zig
+++ b/src/help.zig
@@ -11,6 +11,7 @@ const main_msg =
     \\get                   Get list of resource on cluster.
     \\diff                  Show the resources Added, Updated and Removed
     \\                      from a cluster by comparing two labels defined in the database.
+    \\snapshot              Take a snapshot of the resources on the cluster at give intervals.
     \\
     \\GLOBAL FLAGS:
     \\-h, --help            Display this help and exit.
@@ -70,6 +71,36 @@ const diff_msg =
     \\
 ;
 
+const snapshot_msg =
+    \\USAGE:
+    \\  kubectlgetall snapshot [FLAGS]
+    \\
+    \\Take a snapshot of the resources on the cluster at given intervals.
+    \\
+    \\REQUIREMENTS:
+    \\kubectl must be installed and available on PATH.
+    \\An active connection to a Kubernetes cluster is required.
+    \\
+    \\FLAGS:
+    \\-h, --help                Display this help and exit.
+    \\-n, --namespace <STR>     Namespace to get resources from.
+    \\-A, --all-namespaces      If present, list all objects across all namespaces.     
+    \\                          Specifying --namespace will be ignored.
+    \\-d, --database <PATH>     Path to the sqlite file to save the results.
+    \\                          If the files does not exist it will be created. [REQUIRED]
+    \\-l, --label <STR>         Set the label that will be saved with entries in the database.
+    \\                          Labels will have a suffix of the snapshot iteration, <LABEL-N> [REQUIRED]
+    \\--delay <TIME>            Time delay between snaphoting the cluster.
+    \\                          Format can be INT, or INTs, INTm, INTh. 
+    \\                          Default time delay of 60, 60s, 1m.
+    \\-c, --count <INT>         Number of sanpshots to take. Default 0, meaning unlimited.
+    \\--limit <TIME>            Max runtime of sanpshot.
+    \\                          If time limit is reached before the count limit is reached the appliction will exit.
+    \\                          Format can be INT, or INTs, INTm, INTh. Default of time limit of 0, meaning unlimited.
+    \\-e, --exclude <STR>...    Exclude crd types. Multiple can be excluded eg: "-e <CRD> -e <CRD>"
+    \\
+;
+
 fn print(
     io: std.Io,
     file: std.Io.File,
@@ -91,4 +122,8 @@ pub fn get(io: std.Io, file: std.Io.File) !void {
 
 pub fn diff(io: std.Io, file: std.Io.File) !void {
     return print(io, file, diff_msg);
+}
+
+pub fn snapshot(io: std.Io, file: std.Io.File) !void {
+    return print(io, file, snapshot_msg);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,6 +10,7 @@ const diff = @import("diff.zig");
 const get = @import("get.zig");
 const logging = @import("log.zig");
 const help = @import("help.zig");
+const snapshot = @import("snapshot.zig");
 
 pub const std_options: std.Options = .{
     .log_level = .debug,
@@ -59,5 +60,6 @@ pub fn main(init: std.process.Init) !void {
     switch (command) {
         .get => try get.getMain(init.io, init.gpa, &iter),
         .diff => try diff.diffMain(init.io, init.gpa, &iter),
+        .snapshot => try snapshot.cmd(init.io, init.gpa, &iter),
     }
 }

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -1,0 +1,123 @@
+const std = @import("std");
+const clap = @import("clap");
+
+const args = @import("args.zig");
+const cluster = @import("cluster.zig");
+const db = @import("database.zig");
+const help = @import("help.zig");
+const logging = @import("log.zig");
+const types = @import("types.zig");
+const utils = @import("utils.zig");
+
+pub fn cmd(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
+    var diag = clap.Diagnostic{};
+    var res = clap.parseEx(clap.Help, &args.snapshot_params, args.snapshot_parsers, iter, .{
+        .diagnostic = &diag,
+        .allocator = gpa,
+    }) catch |err| {
+        // Report useful error and exit.
+        try diag.reportToFile(io, .stderr(), err);
+        return err;
+    };
+    defer res.deinit();
+
+    if (res.args.help != 0) {
+        try help.snapshot(io, .stdout());
+        std.process.exit(0);
+    }
+
+    if (res.args.@"log-level") |l| {
+        logging.setLogLevel(l);
+    }
+
+    var config = types.SnapshotConfig{
+        .database = res.args.database orelse return error.MissingDatabase,
+        .label = res.args.label orelse return error.MissingLabel,
+        .exclude = if (res.args.exclude.len > 0) res.args.exclude else null,
+        .all = if (res.args.@"all-namespaces" == 1) true else false,
+        .namespace = if (res.args.namespace) |n| n else "",
+        .startTime = std.Io.Timestamp.now(io, .real).toSeconds(),
+    };
+
+    if (res.args.delay) |v| config.delay = @intCast(v);
+    if (res.args.limit) |v| config.limit = @intCast(v);
+    if (res.args.count) |v| config.count = v;
+
+    std.log.debug("{f}", .{config});
+
+    try db.init(config.database);
+
+    var run = true;
+    const endTime = config.startTime + config.limit;
+    while (run) {
+        if (config.count > 0) {
+            std.log.info("Starting snapshot run {} of {}.", .{ config.interation + 1, config.count });
+        } else {
+            std.log.info("Starting snapshot run {}.", .{config.interation + 1});
+        }
+        std.log.debug("{f}", .{config});
+
+        var crdTypes = cluster.getCrdList(io, gpa) catch |err| switch (err) {
+            error.BadExit => {
+                std.log.err("Kubectl returned a none zero exit code", .{});
+                std.process.exit(1);
+            },
+            else => return err,
+        };
+        defer {
+            for (crdTypes.items) |item| {
+                gpa.free(item);
+            }
+            crdTypes.deinit(gpa);
+        }
+        std.log.info("Total number of CRD types found {}.", .{crdTypes.items.len});
+
+        const timestamp = std.Io.Timestamp.now(io, .real).toSeconds();
+        const label = try std.fmt.allocPrint(gpa, "{s}-{}", .{ config.label, config.interation });
+        defer gpa.free(label);
+
+        for (crdTypes.items) |line| {
+            if (utils.matchedExclude(config.exclude, line)) |matched| {
+                std.log.debug("excluding resource {s} matched by -e {s}", .{ line, matched });
+                continue;
+            }
+
+            const resource = cluster.getCRJson(io, gpa, config, line) catch |err| switch (err) {
+                error.NoData => {
+                    continue;
+                },
+                else => return err,
+            };
+            defer resource.deinit(gpa);
+
+            if (resource.items.len > 0) {
+                if (utils.matchedExclude(config.exclude, resource.items[0].kind)) |matched| {
+                    std.log.debug("excluding {s}/{s} matched by -e {s}", .{ resource.items[0].apiVersion, resource.items[0].kind, matched });
+                    resource.deinit(gpa);
+                    continue;
+                }
+            }
+
+            try db.add(resource, label, timestamp);
+        }
+
+        // Below are the steps required to quit the loops when required.
+        config.interation += 1;
+        if (config.count != 0 and config.count <= config.interation) {
+            std.log.info("Run count limit reached.", .{});
+            run = false;
+            continue;
+        }
+
+        const nextTime = if (config.limit > 0) std.Io.Timestamp.now(io, .real).toSeconds() + config.delay else endTime - 1;
+
+        if (endTime < nextTime) {
+            run = false;
+            std.log.info("Next wait will take longer than time limit allows, exiting early.", .{});
+            continue;
+        }
+
+        std.log.info("Waiting {} seconds before next snapshot.", .{config.delay});
+        try std.Io.sleep(io, std.Io.Duration.fromSeconds(config.delay), .real);
+    }
+}

--- a/src/types.zig
+++ b/src/types.zig
@@ -67,6 +67,49 @@ pub const DiffConfig = struct {
     }
 };
 
+pub const SnapshotConfig = struct {
+    database: []const u8,
+    label: []const u8,
+    exclude: ?[]const []const u8 = null,
+    count: u64 = 0,
+    limit: i64 = 0,
+    delay: i64 = 60,
+    namespace: []const u8,
+    all: bool,
+    startTime: i64,
+    interation: usize = 0,
+
+    pub fn format(self: @This(), writer: *std.Io.Writer) std.Io.Writer.Error!void {
+        try writer.print(
+            "Configuration:\n\tnamespace: {s}\n\tall namespaces: {}\n\tdatabase: {s}\n\tlabel: {s}\n\tstart time: {}\n\tcount: {}\n\tlimit: {}\n\tdelay: {}\n\tinteration: {}\n\texclude: ",
+            .{
+                self.namespace,
+                self.all,
+                self.database,
+                self.label,
+                self.startTime,
+                self.count,
+                self.limit,
+                self.delay,
+                self.interation,
+            },
+        );
+
+        if (self.exclude) |items| {
+            try writer.writeAll("[");
+            for (items, 0..) |item, i| {
+                if (i > 0) try writer.writeAll(", ");
+                try writer.print("{s}", .{item});
+            }
+            try writer.writeAll("]\n");
+        } else {
+            try writer.writeAll("null\n");
+        }
+
+        try writer.flush();
+    }
+};
+
 pub const Metadata = struct {
     name: []const u8,
     namespace: []const u8,

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -9,6 +9,10 @@ pub fn matchedExclude(haystack: ?[]const []const u8, needle: []const u8) ?[]cons
     return null;
 }
 
+pub fn compareStrings(_: void, lhs: []const u8, rhs: []const u8) bool {
+    return std.mem.lessThan(u8, lhs, rhs);
+}
+
 test "null haystack returns null" {
     try std.testing.expectEqual(null, matchedExclude(null, "Pod"));
 }


### PR DESCRIPTION
# Description

Adds a new `snapshot` subcommand that captures the state of cluster resources at configurable intervals, saving each snapshot to a SQLite database with auto-suffixed labels (`<label>-0`, `<label>-1`, ...). The command supports a time-based `--delay` between runs, a `--count` limit on iterations, and a `--limit` on total runtime. This lays the groundwork for future detection of runaway resource generation.

Also adds a summary section to the `diff` command output (both TTY and JSON formats) showing counts of added, updated, and deleted resources.

CLI argument definitions and shared cluster interaction functions (`getCrdList`, `getCRJson`) have been extracted from `get.zig` into dedicated `args.zig` and `cluster.zig` modules so they can be reused by both the `get` and `snapshot` commands. The `compareStrings` utility was similarly moved to `utils.zig`.
